### PR TITLE
Make the default version search pattern for tags more liberal.

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
@@ -62,7 +62,7 @@ public class GitVersionCalculator implements AutoCloseable, MetadataProvider {
     private List<BranchingPolicy> qualifierBranchingPolicies;
     private boolean useDefaultBranchingPolicy = true;
 
-    private String findTagVersionPattern = "v?([0-9]+(?:\\.[0-9]+){0,2}(?:-[a-zA-Z0-9\\-_]+)?)";
+    private String findTagVersionPattern = "[^0-9]*([0-9]+(?:\\.[0-9]+){0,2}(?:-[a-zA-Z0-9\\-_]+)?)";
     private String extractTagVersionPattern = "$1";
     private File gitRepositoryLocation;
 


### PR DESCRIPTION
In our default version tagging scheme we prefix all tags with "version/".
So instead of "1.2.3" as a version tag, we have "version/1.2.3".

This commit makes the default version pattern matcher ignore every prefix that does not contain numbers.
So "banana/1.2.3" would also count as a version tag even though we have no idea why people would want to prefix their version numbers with banana's.

A few comments:
- It would be even nicer if that pattern was configuratble - so part of the jgitver.config.xml
- VersionNamingConfiguration.java should probably have constructors that takes Pattern objects rather than strings.
- These defaults should probably be located there as well, so you could have a constructor that takes no patterns but instead uses the default built-in patterns.

None of the above is a big deal, it's a pretty nice codebase overall.