### PR TITLE
Add useMaxVersion semantics to all VersionStrategy implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 target/
 .classpath
 .project

--- a/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
@@ -64,6 +64,8 @@ public class GitVersionCalculator implements AutoCloseable, MetadataProvider {
     private boolean useGitCommitTimestamp = false;
     private boolean useDirty = false;
     private boolean useLongFormat = false;
+    private boolean useMaxVersion = false;
+    private int maxVersionSearchDepth = 500;
     private int gitCommitIdLength = 8;
     private List<BranchingPolicy> qualifierBranchingPolicies;
     private boolean useDefaultBranchingPolicy = true;
@@ -151,6 +153,8 @@ public class GitVersionCalculator implements AutoCloseable, MetadataProvider {
                     cvs.setGitCommitIdLength(gitCommitIdLength);
                     cvs.setUseCommitTimestamp(useGitCommitTimestamp);
                     cvs.setUseLongFormat(useLongFormat);
+                    cvs.setUseMaxVersion(useMaxVersion);
+                    cvs.setMaxVersionSearchDepth(maxVersionSearchDepth);
                     strategy = cvs;
                     break;
                 case PATTERN:
@@ -568,6 +572,16 @@ public class GitVersionCalculator implements AutoCloseable, MetadataProvider {
      */
     public GitVersionCalculator setVersionPattern(String pattern) {
         this.versionPattern = pattern;
+        return this;
+    }
+
+    public GitVersionCalculator setUseMaxVersion(boolean useMaxVersion) {
+        this.useMaxVersion = useMaxVersion;
+        return this;
+    }
+
+    public GitVersionCalculator setMaxVersionSearchDepth(int maxVersionSearchDepth) {
+        this.maxVersionSearchDepth = maxVersionSearchDepth;
         return this;
     }
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
@@ -140,36 +140,36 @@ public class GitVersionCalculator implements AutoCloseable, MetadataProvider {
 
             switch (versionStrategy) {
                 case MAVEN:
-                    final MavenVersionStrategy mavenStrategy = new MavenVersionStrategy(vnc, repository, git, metadatas);
-                    mavenStrategy.setUseDirty(useDirty);
-                    strategy = mavenStrategy;
+                    strategy = new MavenVersionStrategy(vnc, repository, git, metadatas)
+                            .setUseMaxVersion(useMaxVersion)
+                            .setMaxVersionSearchDepth(maxVersionSearchDepth)
+                            .setUseDirty(useDirty);
                     break;
                 case CONFIGURABLE:
-                    ConfigurableVersionStrategy cvs = new ConfigurableVersionStrategy(vnc, repository, git, metadatas);
-                    cvs.setAutoIncrementPatch(autoIncrementPatch);
-                    cvs.setUseDistance(useDistance);
-                    cvs.setUseDirty(useDirty);
-                    cvs.setUseGitCommitId(useGitCommitId);
-                    cvs.setGitCommitIdLength(gitCommitIdLength);
-                    cvs.setUseCommitTimestamp(useGitCommitTimestamp);
-                    cvs.setUseLongFormat(useLongFormat);
-                    cvs.setUseMaxVersion(useMaxVersion);
-                    cvs.setMaxVersionSearchDepth(maxVersionSearchDepth);
-                    strategy = cvs;
+                    strategy = new ConfigurableVersionStrategy(vnc, repository, git, metadatas)
+                            .setAutoIncrementPatch(autoIncrementPatch)
+                            .setUseDistance(useDistance)
+                            .setUseDirty(useDirty)
+                            .setUseGitCommitId(useGitCommitId)
+                            .setGitCommitIdLength(gitCommitIdLength)
+                            .setUseCommitTimestamp(useGitCommitTimestamp)
+                            .setUseLongFormat(useLongFormat)
+                            .setUseMaxVersion(useMaxVersion)
+                            .setMaxVersionSearchDepth(maxVersionSearchDepth);
                     break;
                 case PATTERN:
-                    PatternVersionStrategy pvs = new PatternVersionStrategy(vnc, repository, git, metadatas);
-                    pvs.setAutoIncrementPatch(autoIncrementPatch);
-                    pvs.setVersionPattern(versionPattern);
-                    pvs.setTagVersionPattern(tagVersionPattern);
-                    strategy = pvs;
+                    strategy = new PatternVersionStrategy(vnc, repository, git, metadatas)
+                            .setAutoIncrementPatch(autoIncrementPatch)
+                            .setVersionPattern(versionPattern)
+                            .setTagVersionPattern(tagVersionPattern)
+                            .setUseMaxVersion(useMaxVersion)
+                            .setMaxVersionSearchDepth(maxVersionSearchDepth);
                     break;
                 default:
                     throw new IllegalStateException("unknown strategy: " + versionStrategy);
             }
 
             Version calculatedVersion = buildVersion(git, strategy);
-
 
             return calculatedVersion;
         }

--- a/src/main/java/fr/brouillard/oss/jgitver/Lambdas.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/Lambdas.java
@@ -99,4 +99,26 @@ public final class Lambdas {
             throw new RuntimeException(caught);
         }
     }
+
+
+    @FunctionalInterface
+    public interface CheckedFunction<T, R, EX extends Throwable> {
+        R apply(T attr) throws EX;
+    }
+
+    public static <T, R> Function<T, R> unchecked(CheckedFunction<T, R, Throwable> function) {
+        return element -> {
+            try {
+                return function.apply(element);
+            } catch (Throwable ex) {
+                return sneakyThrow(ex);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable, T> T sneakyThrow(Throwable t) throws E {
+        throw (E) t;
+    }
+
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/Version.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/Version.java
@@ -18,12 +18,13 @@ package fr.brouillard.oss.jgitver;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Version {
+public class Version implements Comparable<Version> {
     public static final Version DEFAULT_VERSION = new Version(0, 0, 0);
     public static final Version EMPTY_REPOSITORY_VERSION = DEFAULT_VERSION.addQualifier("EMPTY_GIT_REPOSITORY");
     public static final Version NOT_GIT_VERSION = DEFAULT_VERSION.addQualifier("NOT_A_GIT_REPOSITORY");
@@ -217,5 +218,15 @@ public class Version {
         result = 31 * result + stringRepresentation.hashCode();
         result = 31 * result + (qualifiers != null ? qualifiers.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public int compareTo(Version o) {
+        return Comparator
+                .comparingInt(Version::getMajor)
+                .thenComparingInt(Version::getMinor)
+                .thenComparingInt(Version::getPatch)
+                .thenComparing(Version::toString)
+                .compare(this, o);
     }
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/ConfigurableVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/ConfigurableVersionStrategy.java
@@ -111,7 +111,7 @@ public class ConfigurableVersionStrategy extends VersionStrategy {
 
             if (tagToUse != null) {
                 String tagName = GitUtils.tagNameFromRef(tagToUse);
-                TagType tagType = computeTagType(tagToUse, base.getAnnotatedTags().stream().findFirst().orElse(null));
+                TagType tagType = computeTagType(tagToUse, maxVersionTag(base.getAnnotatedTags()).orElse(null));
                 getRegistrar().registerMetadata(Metadatas.BASE_TAG_TYPE, tagType.name());
                 getRegistrar().registerMetadata(Metadatas.BASE_TAG, tagName);
                 baseVersion = tagToVersion(tagName);

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/MavenVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/MavenVersionStrategy.java
@@ -28,9 +28,8 @@ import fr.brouillard.oss.jgitver.Version;
 import fr.brouillard.oss.jgitver.VersionCalculationException;
 import fr.brouillard.oss.jgitver.metadata.MetadataRegistrar;
 import fr.brouillard.oss.jgitver.metadata.Metadatas;
-import fr.brouillard.oss.jgitver.metadata.TagType;
 
-public class MavenVersionStrategy extends VersionStrategy {
+public class MavenVersionStrategy extends MaxVersionStrategy<MavenVersionStrategy> {
     private boolean useDirty = false;
 
     public MavenVersionStrategy(VersionNamingConfiguration vnc, Repository repository, Git git, MetadataRegistrar metadatas) {
@@ -38,43 +37,17 @@ public class MavenVersionStrategy extends VersionStrategy {
     }
 
     @Override
-    public Version build(Commit head, List<Commit> parentsWithTags) throws VersionCalculationException {
+    public Version build(Commit head, List<Commit> parents) throws VersionCalculationException {
         try {
-            Commit base = parentsWithTags.get(0);
+            Commit base = findVersionCommit(head, parents);
+            Ref tagToUse = findTagToUse(head, base);
+            Version baseVersion = getBaseVersionAndRegisterMetadata(base, tagToUse);
+            boolean needSnapshot = true;
 
-            Ref tagToUse;
-            if (isBaseCommitOnHead(head, base) && !GitUtils.isDirty(getGit())) {
-                // consider first the annotated tags
-                tagToUse = base.getAnnotatedTags().stream().findFirst()
-                        .orElseGet(() -> base.getLightTags().stream().findFirst().orElse(null));
-            } else {
-                // consider first the light tags
-                tagToUse = base.getLightTags().stream().findFirst()
-                        .orElseGet(() -> base.getAnnotatedTags().stream().findFirst().orElse(null));
-            }
-
-            Version baseVersion = null;
-            boolean needSnapshot = false;
-
-            if (tagToUse == null) {
-                // we have reached the first commit of the repository and this commit is still no annotated
-                // Let's use a default version.
-                baseVersion = Version.DEFAULT_VERSION;
-                needSnapshot = true;
-            } else {
-                String tagName = GitUtils.tagNameFromRef(tagToUse);
-                TagType tagType = computeTagType(tagToUse, base.getAnnotatedTags().stream().findFirst().orElse(null));
-                getRegistrar().registerMetadata(Metadatas.BASE_TAG, tagName);
-                getRegistrar().registerMetadata(Metadatas.BASE_TAG_TYPE, tagType.name());
-                baseVersion = Version
-                        .parse(getVersionNamingConfiguration().extractVersionFrom(tagName));
+            if (tagToUse != null) {
                 needSnapshot = baseVersion.isSnapshot() || !isBaseCommitOnHead(head, base)
                         || !GitUtils.isAnnotated(tagToUse);
             }
-            getRegistrar().registerMetadata(Metadatas.BASE_VERSION, baseVersion.toString());
-            getRegistrar().registerMetadata(Metadatas.CURRENT_VERSION_MAJOR, "" + baseVersion.getMajor());
-            getRegistrar().registerMetadata(Metadatas.CURRENT_VERSION_MINOR, "" + baseVersion.getMinor());
-            getRegistrar().registerMetadata(Metadatas.CURRENT_VERSION_PATCH, "" + baseVersion.getPatch());
 
             if (!isBaseCommitOnHead(head, base)) {
                 // we are not on head
@@ -112,7 +85,7 @@ public class MavenVersionStrategy extends VersionStrategy {
         }
     }
 
-    public void setUseDirty(boolean useDirty) {
-        this.useDirty = useDirty;
+    public MavenVersionStrategy setUseDirty(boolean useDirty) {
+        return runAndGetSelf(() -> this.useDirty = useDirty);
     }
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/MaxVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/MaxVersionStrategy.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.impl;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+
+import fr.brouillard.oss.jgitver.Lambdas;
+import fr.brouillard.oss.jgitver.Version;
+import fr.brouillard.oss.jgitver.metadata.MetadataRegistrar;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.metadata.TagType;
+
+public abstract class MaxVersionStrategy<T extends MaxVersionStrategy> extends VersionStrategy {
+    protected boolean useMaxVersion;
+    protected int maxVersionSearchDepth = 1000;
+
+    protected MaxVersionStrategy(VersionNamingConfiguration vnc, Repository repository, Git git, MetadataRegistrar metadatas) {
+        super(vnc, repository, git, metadatas);
+    }
+
+    @Override
+    public StrategySearchMode searchMode() {
+        return useMaxVersion ? StrategySearchMode.DEPTH : StrategySearchMode.STOP_AT_FIRST;
+    }
+
+    @Override
+    public int searchDepthLimit() {
+        return maxVersionSearchDepth;
+    }
+
+    protected Version getBaseVersionAndRegisterMetadata(Commit base, Ref tagToUse) {
+        Version baseVersion = Version.DEFAULT_VERSION;
+
+        if (tagToUse != null) {
+            String tagName = GitUtils.tagNameFromRef(tagToUse);
+            TagType tagType = computeTagType(tagToUse, maxVersionTag(base.getAnnotatedTags()).orElse(null));
+            baseVersion = tagToVersion(tagName);
+
+            getRegistrar().registerMetadata(Metadatas.BASE_TAG_TYPE, tagType.name());
+            getRegistrar().registerMetadata(Metadatas.BASE_TAG, tagName);
+        }
+        
+        getRegistrar().registerMetadata(Metadatas.BASE_VERSION, baseVersion.toString());
+        getRegistrar().registerMetadata(Metadatas.CURRENT_VERSION_MAJOR, Integer.toString(baseVersion.getMajor()));
+        getRegistrar().registerMetadata(Metadatas.CURRENT_VERSION_MINOR, Integer.toString(baseVersion.getMinor()));
+        getRegistrar().registerMetadata(Metadatas.CURRENT_VERSION_PATCH, Integer.toString(baseVersion.getPatch()));
+
+        return baseVersion;
+    }
+
+    public T setUseMaxVersion(boolean useMaxVersion) {
+        return runAndGetSelf(() -> this.useMaxVersion = useMaxVersion);
+    }
+
+    public T setMaxVersionSearchDepth(int maxVersionSearchDepth) {
+        return runAndGetSelf(() -> this.maxVersionSearchDepth = maxVersionSearchDepth);
+    }
+
+    protected T runAndGetSelf(Runnable runnable) {
+        runnable.run();
+        return self();
+    }
+
+    protected T self() {
+        return (T) this;
+    }
+
+    protected Version tagToVersion(String tagName) {
+        return Version.parse(getVersionNamingConfiguration().extractVersionFrom(tagName));
+    }
+
+    protected boolean isGitDirty() {
+        return Lambdas.unchecked(GitUtils::isDirty).apply(getGit());
+    }
+
+    protected Ref findTagToUse(Commit head, Commit base) {
+        return isBaseCommitOnHead(head, base) && !isGitDirty()
+                ? maxVersionTag(base.getAnnotatedTags(), base.getLightTags())
+                : maxVersionTag(base.getLightTags(), base.getAnnotatedTags());
+    }
+
+    protected Commit findVersionCommit(Commit head, List<Commit> parents) {
+        return useMaxVersion ? findMaxVersionCommit(head, parents) : parents.get(0);
+    }
+
+    protected Commit findMaxVersionCommit(Commit head, List<Commit> parents) {
+        return parents.stream()
+                .limit(maxVersionSearchDepth)
+                .map(commit -> toVersionTarget(head, commit))
+                .max(Comparator.naturalOrder())
+                .map(VersionTarget::getTarget)
+                .orElse(parents.get(0));
+    }
+
+    protected Ref maxVersionTag(List<Ref> primaryTags, List<Ref> secondaryTags) {
+        return maxVersionTag(primaryTags).orElseGet(() -> maxVersionTag(secondaryTags).orElse(null));
+    }
+
+    protected Optional<Ref> maxVersionTag(List<Ref> tags) {
+        return tags.stream()
+                .map(this::toVersionTarget)
+                .max(Comparator.naturalOrder())
+                .map(VersionTarget::getTarget);
+    }
+
+    protected VersionTarget<Ref> toVersionTarget(Ref tagRef) {
+        String tagName = GitUtils.tagNameFromRef(tagRef);
+        return new VersionTarget<>(tagToVersion(tagName), tagRef);
+    }
+
+    protected VersionTarget<Commit> toVersionTarget(Commit head, Commit commit) {
+        String tagName = GitUtils.tagNameFromRef(findTagToUse(head, commit));
+        Version version = Version.parse(tagName);
+        return new VersionTarget<>(version, commit);
+    }
+
+    private static class VersionTarget<T> implements Comparable<VersionTarget<T>> {
+        private final Version version;
+        private final T target;
+
+        VersionTarget(Version version, T target) {
+            this.version = version;
+            this.target = target;
+        }
+
+        Version getVersion() {
+            return version;
+        }
+
+        T getTarget() {
+            return target;
+        }
+
+        @Override
+        public int compareTo(VersionTarget versionTarget) {
+            return this.version.compareTo(versionTarget.version);
+        }
+    }
+
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/configurable/others/Scenario14WithMaxVersionTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/configurable/others/Scenario14WithMaxVersionTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.configurable.others;
+
+import static fr.brouillard.oss.jgitver.Lambdas.mute;
+import static fr.brouillard.oss.jgitver.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.*;
+
+import fr.brouillard.oss.jgitver.GitVersionCalculator;
+import fr.brouillard.oss.jgitver.Misc;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Scenarios.Scenario;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+
+public class Scenario14WithMaxVersionTest {
+    private static Scenario scenario;
+    private Repository repository;
+    private Git git;
+    private GitVersionCalculator versionCalculator;
+
+    /**
+     * Initialiaze the whole junit class tests ; creates the git scenario.
+     */
+    @BeforeClass
+    public static void initClass() {
+        scenario = Scenarios.s14_with_merges();
+        if (Misc.isDebugMode()) {
+            System.out.println("git repository created under: " + scenario.getRepositoryLocation());
+        }
+    }
+
+    /**
+     * Cleanup the whole junit scenario ; deletes the created git repository.
+     */
+    @AfterClass
+    public static void cleanupClass() {
+        try {
+            Misc.deleteDirectorySimple(scenario.getRepositoryLocation());
+        } catch (Exception ignore) {
+            System.err.println("cannot remove " + scenario.getRepositoryLocation());
+        }
+    }
+
+    /**
+     * Prepare common variables to access the git repository.
+     *
+     * @throws IOException if a disk error occurred
+     */
+    @Before
+    public void init() throws IOException {
+        repository = new FileRepositoryBuilder().setGitDir(scenario.getRepositoryLocation()).build();
+        git = new Git(repository);
+        versionCalculator = GitVersionCalculator
+                .location(scenario.getRepositoryLocation())
+                .setNonQualifierBranches("master,hotfix")
+                .setUseMaxVersion(true);
+
+        // reset the head to master
+        unchecked(() -> git.checkout().setName("master").call());
+    }
+
+    /**
+     * Cleanups after each tests.
+     */
+    @After
+    public void clean() {
+        mute(() -> git.close());
+        mute(() -> repository.close());
+        mute(() -> versionCalculator.close());
+    }
+
+
+    @Test
+    public void version_of_B_commit() {
+        ObjectId cCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-0"));
+    }
+
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+
+    @Test
+    public void version_of_E_commit() {
+        ObjectId cCommit = scenario.getCommits().get("E");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.1.1-1"));
+    }
+
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.1-3"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("2.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("1.2.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("1.1.2"));
+    }
+
+    @Test
+    public void version_of_branch_hotfix() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("hotfix").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.1"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/maven/others/Scenario14WithMaxVersionTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/maven/others/Scenario14WithMaxVersionTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package fr.brouillard.oss.jgitver.strategy.configurable.others;
+package fr.brouillard.oss.jgitver.strategy.maven.others;
 
 import static fr.brouillard.oss.jgitver.Lambdas.mute;
 import static fr.brouillard.oss.jgitver.Lambdas.unchecked;
@@ -79,7 +79,8 @@ public class Scenario14WithMaxVersionTest {
         versionCalculator = GitVersionCalculator
                 .location(scenario.getRepositoryLocation())
                 .setNonQualifierBranches("master,hotfix")
-                .setUseMaxVersion(true);
+                .setUseMaxVersion(true)
+                .setMavenLike(true);
 
         // reset the head to master
         unchecked(() -> git.checkout().setName("master").call());
@@ -95,13 +96,14 @@ public class Scenario14WithMaxVersionTest {
         mute(() -> versionCalculator.close());
     }
 
+
     @Test
     public void version_of_B_commit() {
         ObjectId cCommit = scenario.getCommits().get("B");
 
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName(cCommit.name()).call());
-        assertThat(versionCalculator.getVersion(), is("1.0.0-0"));
+        assertThat(versionCalculator.getVersion(), is("1.0.0-SNAPSHOT"));
     }
 
     @Test
@@ -110,7 +112,7 @@ public class Scenario14WithMaxVersionTest {
 
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName(cCommit.name()).call());
-        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+        assertThat(versionCalculator.getVersion(), is("1.0.0-SNAPSHOT"));
     }
 
     @Test
@@ -119,14 +121,14 @@ public class Scenario14WithMaxVersionTest {
 
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName(cCommit.name()).call());
-        assertThat(versionCalculator.getVersion(), is("1.1.1-1"));
+        assertThat(versionCalculator.getVersion(), is("1.1.2-SNAPSHOT"));
     }
 
     @Test
     public void version_of_master() {
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName("master").call());
-        assertThat(versionCalculator.getVersion(), is("1.1.1-3"));
+        assertThat(versionCalculator.getVersion(), is("1.1.2-SNAPSHOT"));
 
         assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("2.0.0"));
         assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("1.2.0"));

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario14WithMaxVersionTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario14WithMaxVersionTest.java
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package fr.brouillard.oss.jgitver.strategy.configurable.others;
+package fr.brouillard.oss.jgitver.strategy.pattern.others;
 
-import static fr.brouillard.oss.jgitver.Lambdas.mute;
-import static fr.brouillard.oss.jgitver.Lambdas.unchecked;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-
+import fr.brouillard.oss.jgitver.GitVersionCalculator;
+import fr.brouillard.oss.jgitver.Misc;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Scenarios.Scenario;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
@@ -32,11 +31,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import fr.brouillard.oss.jgitver.GitVersionCalculator;
-import fr.brouillard.oss.jgitver.Misc;
-import fr.brouillard.oss.jgitver.Scenarios;
-import fr.brouillard.oss.jgitver.Scenarios.Scenario;
-import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import java.io.IOException;
+
+import static fr.brouillard.oss.jgitver.Lambdas.mute;
+import static fr.brouillard.oss.jgitver.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class Scenario14WithMaxVersionTest {
     private static Scenario scenario;
@@ -79,7 +79,8 @@ public class Scenario14WithMaxVersionTest {
         versionCalculator = GitVersionCalculator
                 .location(scenario.getRepositoryLocation())
                 .setNonQualifierBranches("master,hotfix")
-                .setUseMaxVersion(true);
+                .setUseMaxVersion(true)
+                .setStrategy(Strategies.PATTERN);
 
         // reset the head to master
         unchecked(() -> git.checkout().setName("master").call());
@@ -94,6 +95,7 @@ public class Scenario14WithMaxVersionTest {
         mute(() -> repository.close());
         mute(() -> versionCalculator.close());
     }
+
 
     @Test
     public void version_of_B_commit() {


### PR DESCRIPTION
Setting useMaxVersion causes to search for max version visible from current HEAD and use that verion
as base version for calculations instead of just using first version found