### PR TITLE
Add ability to use the plugin on `git worktree`

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/Version.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/Version.java
@@ -29,7 +29,8 @@ public class Version implements Comparable<Version> {
     public static final Version DEFAULT_VERSION = new Version(0, 0, 0);
     public static final Version EMPTY_REPOSITORY_VERSION = DEFAULT_VERSION.addQualifier("EMPTY_GIT_REPOSITORY");
     public static final Version NOT_GIT_VERSION = DEFAULT_VERSION.addQualifier("NOT_A_GIT_REPOSITORY");
-    
+    public static final Version NO_WORKTREE_AND_INDEX = DEFAULT_VERSION.addQualifier("NO_WORKTREE_AND_INDEX");
+
     private final int major;
 
     private final int minor;

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Ref;
@@ -345,6 +346,9 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
             provideNextVersionsMetadatas(calculatedVersion, patchVersionIsIncremented);
 
             return calculatedVersion;
+        } catch (NoWorkTreeException ex) {
+            // Could not find worktree and index - assuming this is a `git worktree` (this assumption should be logged as debug)
+            return Version.NO_WORKTREE_AND_INDEX;
         } catch (Exception ex) {
             throw new IllegalStateException("failure calculating version", ex);
         }


### PR DESCRIPTION
The jgit does not support `git worktree` and breaks execution of the plugin by throwing an exception.
To avoid breaking the build, the exception is caught instead and the default version `0.0.0-NO_WORKTREE_AND_INDEX` is assigned.