### PR TITLE
Specify the distribution as Ubuntu Trusty to use oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 git:


### PR DESCRIPTION
Fixes #94