### PR TITLE
Add CLI options for qualifier branch policies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <petitparser-core.version>2.2.0</petitparser-core.version>
 
         <!-- optional dependencies, for use with the CLI -->
-        <picocli.version>3.9.6</picocli.version>
+        <picocli.version>4.0.4</picocli.version>
         <slf4j-nop.version>1.7.26</slf4j-nop.version>
 
         <!-- test dependencies -->

--- a/src/main/java/fr/brouillard/oss/jgitver/cli/Options.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/cli/Options.java
@@ -16,9 +16,12 @@
 package fr.brouillard.oss.jgitver.cli;
 
 import java.io.File;
+import java.util.List;
 
+import fr.brouillard.oss.jgitver.BranchingPolicy;
 import fr.brouillard.oss.jgitver.LookupPolicy;
 import fr.brouillard.oss.jgitver.Strategies;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -76,4 +79,16 @@ public class Options {
 
     @Option(names = {"--metas", "--metadatas"}, description = "metadatas to show, separated by ','")
     String metadatas;
+
+    @ArgGroup(exclusive = false, multiplicity = "*")
+    List<QualifierBranchPolicy> qualifierBranchPolicies;
+
+    static class QualifierBranchPolicy {
+        @Option(names = "--branchPolicyPattern", required = true, description = "regex to match a branch name")
+        String branchPolicyPattern;
+        @Option(names = "--branchPolicyTransformations",
+                split = ",",
+                description = "transformations to apply to the branchPolicyPattern match")
+        List<BranchingPolicy.BranchNameTransformations> branchPolicyTransformations;
+    }
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/cli/RunnableCLI.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/cli/RunnableCLI.java
@@ -53,7 +53,7 @@ public class RunnableCLI {
         CommandLine cli = new CommandLine(opts);
 
         try {
-            cli.parse(args);
+            cli.parseArgs(args);
         } catch (CommandLine.UnmatchedArgumentException ex) {
             CommandLine.usage(new Options(), error);
             return 1;

--- a/src/main/java/fr/brouillard/oss/jgitver/cli/RunnableCLI.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/cli/RunnableCLI.java
@@ -17,11 +17,10 @@ package fr.brouillard.oss.jgitver.cli;
 
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import fr.brouillard.oss.jgitver.BranchingPolicy;
 import fr.brouillard.oss.jgitver.GitVersionCalculator;
 import fr.brouillard.oss.jgitver.JGitverProperties;
 import fr.brouillard.oss.jgitver.metadata.Metadatas;
@@ -90,6 +89,32 @@ public class RunnableCLI {
             gvc.setFindTagVersionPattern(opts.pattern);
         }
         gvc.setLookupPolicy(opts.policy);
+
+        if (opts.qualifierBranchPolicies != null) {
+            gvc.setQualifierBranchingPolicies(opts.qualifierBranchPolicies
+                    .stream()
+                    .map(
+                            (Options.QualifierBranchPolicy policy) -> {
+                                if(policy.branchPolicyPattern == null) {
+                                    throw new IllegalArgumentException(
+                                            "Each usage of branchPolicyTransformation must have a branchPolicyPattern");
+                                }
+
+                                if (policy.branchPolicyTransformations != null
+                                        && policy.branchPolicyTransformations.size() > 0) {
+                                    return new BranchingPolicy(
+                                            policy.branchPolicyPattern,
+                                            policy.branchPolicyTransformations
+                                                    .stream()
+                                                    .map(BranchingPolicy.BranchNameTransformations::name)
+                                                    .collect(Collectors.toList()));
+                                } else {
+                                    return new BranchingPolicy(policy.branchPolicyPattern);
+                                }
+                            }
+                    )
+                    .collect(Collectors.toList()));
+        }
 
         if (opts.nonQualifierBranches != null) {
             gvc.setNonQualifierBranches(opts.nonQualifierBranches);

--- a/src/test/java/fr/brouillard/oss/jgitver/cli/CLIQualifierBranchPoliciesTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/cli/CLIQualifierBranchPoliciesTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/fr/brouillard/oss/jgitver/cli/CLIQualifierBranchPoliciesTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/cli/CLIQualifierBranchPoliciesTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.cli;
+
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class CLIQualifierBranchPoliciesTest extends ScenarioTest {
+
+    public CLIQualifierBranchPoliciesTest() {
+        super(
+                Scenarios::s13_gitflow,
+                calculator -> calculator.setStrategy(Strategies.CONFIGURABLE));
+    }
+
+    @Test
+    public void version_of_feature() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call();
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2-feature_add_sso"));
+    }
+
+    @Test
+    public void version_of_feature_other_pattern() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call("--branchPolicyPattern=release/(.*)");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2-feature_add_sso"));
+    }
+
+    @Test
+    public void version_of_feature_branch_part() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call("--branchPolicyPattern=feature/(.*)");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2-add_sso"));
+    }
+
+    @Test
+    public void version_of_feature_branch_part_extra_patterns() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call("--branchPolicyPattern=feature/(.*)",
+                "--branchPolicyPattern=release/(.*)",
+                "--branchPolicyPattern=foo");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2-add_sso"));
+    }
+
+    @Test
+    public void version_of_feature_ignore() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call("--branchPolicyPattern=feature/(.*)", "--branchPolicyTransformations=IGNORE");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2"));
+    }
+
+    @Test
+    public void version_of_feature_ignore_reversed() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call("--branchPolicyTransformations=IGNORE", "--branchPolicyPattern=feature/(.*)");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2"));
+    }
+
+    @Test
+    public void version_of_feature_group_with_default() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call(
+                "--branchPolicyPattern=feature/(.*)",
+                "--branchPolicyPattern=release/(.*)",
+                "--branchPolicyTransformations=IGNORE");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2-add_sso"));
+    }
+
+    @Test
+    public void version_of_feature_group_with_default_elsewhere() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call(
+                "--branchPolicyPattern=feature/(.*)",
+                "--branchPolicyTransformations=IGNORE",
+                "--branchPolicyPattern=release/(.*)");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2"));
+    }
+
+    @Test
+    public void version_of_feature_groups() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        cliCaller.call(
+                "--branchPolicyPattern=feature/(.*)",
+                "--branchPolicyTransformations=IDENTITY,UPPERCASE",
+                "--branchPolicyPattern=release/(.*)",
+                "--branchPolicyTransformations=IGNORE");
+        List<String> lines = cliCaller.getLines();
+        assertThat(lines.size(), is(1));
+        assertThat(lines.get(0), is("1.0.1-2-ADD-SSO"));
+    }
+
+    @Test
+    public void dangling_transformation_exception() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> cliCaller.call("--branchPolicyTransformations=IGNORE")
+        );
+    }
+
+    @Test
+    public void dangling_transformations_exception() {
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+
+        CLICaller cliCaller = new CLICaller(scenario.getRepositoryLocation());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> cliCaller.call("--branchPolicyPattern=feature/(.*)",
+                        "--branchPolicyTransformations=IDENTITY,UPPERCASE",
+                        "--branchPolicyTransformations=IGNORE")
+        );
+    }
+}


### PR DESCRIPTION
Adds `--branchPolicyPattern` and `--branchPolicyTransformations` as a picocli ArgGroup (they can be defined multiple times and picocli handles the complicated logic of grouping them together, examples of the behavior are in the test file but it is basically exactly how you'd expect).

This PR involves bumping picocli above 4.0.0; we didn't use any of the things that changed so there aren't any problems (though the `parse` method was deprecated in favor of `parseArgs`, the return type changed by we don't use the returned value).