### PR TITLE
Add git commitId for tags with useGitCommitId

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/impl/ConfigurableVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/ConfigurableVersionStrategy.java
@@ -120,11 +120,7 @@ public class ConfigurableVersionStrategy extends VersionStrategy<ConfigurableVer
                 }
             }
 
-            boolean needsCommitId = useGitCommitId
-                    && !(isBaseCommitOnHead(head, base)
-                    && !baseVersion.noQualifier().equals(Version.DEFAULT_VERSION));
-
-            if (useLongFormat || needsCommitId) {
+            if (useLongFormat || useGitCommitId) {
                 String commitIdQualifier =
                         (useLongFormat ? "g" : "") + head.getGitObject().getName().substring(0, useLongFormat ? 8 : gitCommitIdLength);
                 baseVersion = baseVersion.addQualifier(commitIdQualifier);

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
@@ -61,8 +61,6 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
             Ref tagToUse = findTagToUse(head, base);
             Version baseVersion = getBaseVersionAndRegisterMetadata(base,tagToUse);
 
-            final boolean useSnapshot = baseVersion.isSnapshot();
-
             if (!isBaseCommitOnHead(head, base) && autoIncrementPatch) {
                 // we are not on head
                 if (GitUtils.isAnnotated(tagToUse)) {

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/configurable/others/Scenario8WithoutGPrefixCommitTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/configurable/others/Scenario8WithoutGPrefixCommitTest.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.api.Test;
 import fr.brouillard.oss.jgitver.Scenarios;
 import fr.brouillard.oss.jgitver.ScenarioTest;
 
-public class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
+class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
 
-    public Scenario8WithoutGPrefixCommitTest() {
+    Scenario8WithoutGPrefixCommitTest() {
         super(
                 Scenarios::s8_main_and_branch_with_intermediate_light_tag,
                 calculator -> calculator
@@ -40,12 +40,12 @@ public class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
     }
 
     @Test
-    public void head_is_on_master_by_default() throws Exception {
+    void head_is_on_master_by_default() throws Exception {
         assertThat(repository.getBranch(), is("master"));
     }
 
     @Test
-    public void version_of_A_commit() {
+    void version_of_A_commit() {
         ObjectId firstCommit = scenario.getCommits().get("A");
 
         // checkout the first commit in scenario
@@ -54,16 +54,16 @@ public class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
     }
 
     @Test
-    public void version_of_B_commit() {
+    void version_of_B_commit() {
         ObjectId bCommit = scenario.getCommits().get("B");
 
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName(bCommit.name()).call());
-        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+        assertThat(versionCalculator.getVersion(), is("1.0.0" + "-" + bCommit.name().substring(0,8)));
     }
 
     @Test
-    public void version_of_C_commit() {
+    void version_of_C_commit() {
         ObjectId cCommit = scenario.getCommits().get("C");
 
         // checkout the commit in scenario
@@ -72,16 +72,16 @@ public class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
     }
 
     @Test
-    public void version_of_D_commit() {
+    void version_of_D_commit() {
         ObjectId dCommit = scenario.getCommits().get("D");
 
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName(dCommit.name()).call());
-        assertThat(versionCalculator.getVersion(), is("1.1.0"));
+        assertThat(versionCalculator.getVersion(), is("1.1.0" + "-" + dCommit.name().substring(0,8)));
     }
 
     @Test
-    public void version_of_E_commit() {
+    void version_of_E_commit() {
         ObjectId eCommit = scenario.getCommits().get("E");
 
         // checkout the commit in scenario
@@ -90,7 +90,7 @@ public class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
     }
 
     @Test
-    public void version_of_F_commit() {
+    void version_of_F_commit() {
         ObjectId fCommit = scenario.getCommits().get("F");
 
         // checkout the commit in scenario
@@ -99,26 +99,26 @@ public class Scenario8WithoutGPrefixCommitTest extends ScenarioTest {
     }
 
     @Test
-    public void version_of_annotated_tags() {
+    void version_of_annotated_tags() {
         unchecked(() -> git.checkout().setName("1.0.0").call());
-        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+        assertThat(versionCalculator.getVersion(), is("1.0.0" + "-" + scenario.getCommits().get("B").name().substring(0,8)));
     }
 
     @Test
-    public void version_of_light_tag_1_1_0() {
+    void version_of_light_tag_1_1_0() {
         unchecked(() -> git.checkout().setName("1.1.0").call());
-        assertThat(versionCalculator.getVersion(), is("1.1.0"));
+        assertThat(versionCalculator.getVersion(), is("1.1.0" + "-" + scenario.getCommits().get("D").name().substring(0,8)));
     }
 
     @Test
-    public void version_of_master() {
+    void version_of_master() {
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName("master").call());
         assertThat(versionCalculator.getVersion(), is("1.1.0" + "-" + scenario.getCommits().get("E").name().substring(0,8)));
     }
 
     @Test
-    public void version_of_branch_issue_10() {
+    void version_of_branch_issue_10() {
         // checkout the commit in scenario
         unchecked(() -> git.checkout().setName("issue-10").call());
         assertThat(versionCalculator.getVersion(), is("1.0.1"+ "-" + scenario.getCommits().get("F").name().substring(0,8) + "-issue_10"));

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario1WithInvalidPatternConfigurationTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario1WithInvalidPatternConfigurationTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.pattern.others;
+
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.impl.VersionCalculationException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Scenario1WithInvalidPatternConfigurationTest {
+
+    @Nested
+    class NonSemverPattern extends ScenarioTest {
+
+        NonSemverPattern() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator.setStrategy(Strategies.PATTERN)
+                            .setVersionPattern("nonSemver"));
+        }
+
+        @Test
+        void versionCalculationException() {
+            ObjectId commit = scenario.getCommits().get("A");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(commit.name()).call());
+            final IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(illegalStateException.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+
+    @Nested
+    class NonSemverTagPattern extends ScenarioTest {
+
+        NonSemverTagPattern() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator.setStrategy(Strategies.PATTERN)
+                            .setTagVersionPattern("nonSemverTagVersionPattern"));
+        }
+
+        @Test
+        void versionCalculationException() {
+            ObjectId commit = scenario.getCommits().get("B");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(commit.name()).call());
+            final IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(illegalStateException.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+}


### PR DESCRIPTION
Remove the "needsCommitId"  test and apply useGitCommitId on tags.

Must fix #90 

I also remove the `public` for the JUnit 5 modified test.