### PR TITLE
Add DIRTY_TEXT metadata

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
@@ -272,8 +272,12 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
 
     private Version buildVersion(Git git, VersionStrategy<?> strategy) {
         try {
-            metadatas.registerMetadata(Metadatas.DIRTY, "" + GitUtils.isDirty(git));
-            
+            boolean dirty = GitUtils.isDirty(git);
+            metadatas.registerMetadata(Metadatas.DIRTY, "" + dirty);
+            if (dirty) {
+                metadatas.registerMetadata(Metadatas.DIRTY_TEXT, "dirty");
+            }
+
             // retrieve all tags matching a version, and get all info for each of them
             List<Ref> allTags = git.tagList().call().stream().map(this::peel)
                     .collect(Collectors.toCollection(ArrayList::new));

--- a/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java
@@ -29,7 +29,12 @@ public enum Metadatas {
     /**
      * Is the repository dirty. 
      */
-    DIRTY, 
+    DIRTY,
+
+    /**
+     * Literally text dirty if the repository is dirty.
+     */
+    DIRTY_TEXT,
     /**
      * Name of the commiter of HEAD commit. 
      */


### PR DESCRIPTION
Hello, Matthieu!
I tried to make tagless releases based on commit hash using `pattern` strategy, but had difficulties with `dirty` metadata. What I wanted is similar to default strategy behaviour: append dirty only if current repo is dirty. I found that it's not possible using available metadata because `meta.DIRTY` is always set to `true` or `false`, so even for tags I got versions like `1.2.3-false` or `1.2.3-true`. This is just not very pretty.
I could live with these kind of tags for non-master branches, but I'd like to haven nice version on release branch, but without https://github.com/jgitver/jgitver/issues/76 it couldn't be done.

So I decided to add `DIRTY_TEXT` metadata to allow users to make `pattern`  strategy to be more like default one. This metadata will be literally word `dirty` of empty `` depending on current state of a repo.
What do you think about this change? Maybe this behaviour can be achieved only by configuration and without code changes?