### PR TITLE
Scriptable strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-script-interpreter</artifactId>
+            <version>1.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
             <version>${org.eclipse.jgit.version}</version>

--- a/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
+import java.lang.reflect.InvocationTargetException;
+
 import fr.brouillard.oss.jgitver.metadata.MetadataProvider;
 import fr.brouillard.oss.jgitver.metadata.Metadatas;
 
@@ -60,9 +62,9 @@ public interface GitVersionCalculator extends AutoCloseable, MetadataProvider {
 
         try {
             Class builderClass = Class.forName("fr.brouillard.oss.jgitver.impl.GitVersionCalculatorImplBuilder");
-            GitVersionCalculatorBuilder builder = (GitVersionCalculatorBuilder) builderClass.newInstance();
+            GitVersionCalculatorBuilder builder = (GitVersionCalculatorBuilder) builderClass.getConstructor().newInstance();
             return builder.build(gitRepositoryLocation);
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+        } catch (ClassNotFoundException | InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException ex) {
             throw new IllegalStateException(
                     "cannot instantiate default GitVersionCalculatorImplBuilder class",
                     ex
@@ -294,4 +296,18 @@ public interface GitVersionCalculator extends AutoCloseable, MetadataProvider {
      * @since 0.13.0
      */
     GitVersionCalculator setForceComputation(boolean forceComputation);
+
+    /**
+     * Set the type of the script (default: {@link ScriptType#GROOVY}).
+     * @param scriptType the script type
+     * @return itself for chaining
+     */
+    GitVersionCalculator setScriptType(ScriptType scriptType);
+
+    /**
+     * Set the script to be interpreted.
+     * @param script the script content
+     * @return itself for chaining
+     */
+    GitVersionCalculator setScript(String script);
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/ScriptType.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/ScriptType.java
@@ -15,6 +15,6 @@
  */
 package fr.brouillard.oss.jgitver;
 
-public enum Strategies {
-    MAVEN, CONFIGURABLE, PATTERN, SCRIPT;
+public enum ScriptType {
+    BEAN_SHELL, GROOVY
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
@@ -55,6 +55,7 @@ import fr.brouillard.oss.jgitver.BranchingPolicy.BranchNameTransformations;
 import fr.brouillard.oss.jgitver.GitVersionCalculator;
 import fr.brouillard.oss.jgitver.LookupPolicy;
 import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.ScriptType;
 import fr.brouillard.oss.jgitver.Version;
 import fr.brouillard.oss.jgitver.impl.metadata.MetadataHolder;
 import fr.brouillard.oss.jgitver.metadata.Metadatas;
@@ -80,6 +81,8 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
     private String tagVersionPattern = null;
     private String versionPattern = null;
     private LookupPolicy lookupPolicy = LookupPolicy.MAX;
+    private ScriptType scriptType = ScriptType.GROOVY;
+    private String script = "";
 
     private final File gitRepositoryLocation;
 
@@ -159,6 +162,11 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
                             .setAutoIncrementPatch(autoIncrementPatch)
                             .setVersionPattern(versionPattern)
                             .setTagVersionPattern(tagVersionPattern);
+                    break;
+                case SCRIPT:
+                    strategy = new ScriptVersionStrategy(vnc, repository, git, metadatas)
+                        .setScriptType(scriptType)
+                        .setScript(script);
                     break;
                 default:
                     throw new IllegalStateException("unknown strategy: " + versionStrategy);
@@ -667,6 +675,18 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
     @Override
     public GitVersionCalculator setForceComputation(boolean forceComputation) {
         this.forceComputation = forceComputation;
+        return this;
+    }
+
+    @Override
+    public GitVersionCalculator setScriptType(ScriptType scriptType) {
+        this.scriptType = scriptType;
+        return this;
+    }
+
+    @Override
+    public GitVersionCalculator setScript(String script) {
+        this.script = script;
         return this;
     }
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/ScriptVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/ScriptVersionStrategy.java
@@ -119,14 +119,22 @@ public class ScriptVersionStrategy extends VersionStrategy<ScriptVersionStrategy
 
             metaProps.put(Metadatas.BRANCH_NAME.name(), branch);
 
+            registrar.registerMetadata(Metadatas.BRANCH_NAME, branch);
+
             getVersionNamingConfiguration().branchQualifier(branch).
-                ifPresent(qualifier ->
-                          metaProps.put(Metadatas.QUALIFIED_BRANCH_NAME.name(),
-                                        qualifier));
+                ifPresent(qualifier -> {
+                        metaProps.put(Metadatas.QUALIFIED_BRANCH_NAME.name(),
+                                      qualifier);
+
+                        registrar.registerMetadata(Metadatas.QUALIFIED_BRANCH_NAME, qualifier);
+                    });
 
             GitUtils.providedBranchName().ifPresent(externalName -> {
                     metaProps.put(Metadatas.QUALIFIED_BRANCH_NAME.name(),
                                   externalName);
+
+                    registrar.registerMetadata(Metadatas.QUALIFIED_BRANCH_NAME,
+                                               externalName);
                 
                     metaProps.put("PROVIDED_BRANCH_NAME", externalName);
                 });
@@ -156,6 +164,11 @@ public class ScriptVersionStrategy extends VersionStrategy<ScriptVersionStrategy
                 baseVersion = versionFromTag(tagToUse);
 
                 metaProps.put(Metadatas.BASE_TAG_TYPE.name(), tagType.name());
+
+                // Required by provideNextVersionsMetadatas
+                registrar.registerMetadata(Metadatas.BASE_TAG_TYPE,
+                                           tagType.name());
+                
                 metaProps.put(Metadatas.BASE_TAG.name(), tagName);
             } else {
                 baseVersion = Version.DEFAULT_VERSION;
@@ -272,8 +285,6 @@ public class ScriptVersionStrategy extends VersionStrategy<ScriptVersionStrategy
 
             return new Version(major, minor, patch, qualifiers);
         } catch (Exception ex) {
-            ex.printStackTrace();
-
             throw new VersionCalculationException("cannot compute version", ex);
         }
     }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/ScriptVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/ScriptVersionStrategy.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.io.InputStream;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.petitparser.context.Result;
+
+import org.apache.maven.shared.scriptinterpreter.BeanShellScriptInterpreter;
+import org.apache.maven.shared.scriptinterpreter.GroovyScriptInterpreter;
+import org.apache.maven.shared.scriptinterpreter.ScriptInterpreter;
+
+import fr.brouillard.oss.jgitver.Features;
+import fr.brouillard.oss.jgitver.ScriptType;
+import fr.brouillard.oss.jgitver.Version;
+
+import fr.brouillard.oss.jgitver.metadata.MetadataProvider;
+import fr.brouillard.oss.jgitver.metadata.MetadataRegistrar;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.metadata.TagType;
+
+/**
+ * Executes the given script (according its {@link ScriptType}, 
+ * default being {@link ScriptType#GROOVY}) 
+ * and use the script output as version.
+ *
+ * This output must be in CSV format using ';' separator, 
+ * with at least the 3 first columns, corresponding to integer values for
+ * major, minor and patch (e.g. <tt>1;2;3</tt>).
+ *
+ * The script has access to <a href="https://jgitver.github.io/#_meta_fields">metadata</a> (e.g. In BeanShell for the SHA1 <tt>metadata.GIT_SHA1_8</tt>).
+ *
+ * The script also has access to the environment variables 
+ * and system properties, respectively thanks to <tt>env</tt> 
+ * (e.g. <tt>env.HOME</tt>) and <tt>sys</tt> (e.g. <tt>sys.user.home</tt>).
+ *
+ * If no script is passed as parameter then the default one is used,
+ * with the same behavior as the <tt>PATTERN</tt> strategy.
+ */
+public class ScriptVersionStrategy extends VersionStrategy<ScriptVersionStrategy> {
+    private ScriptType scriptType = ScriptType.GROOVY;
+    private String script = "";
+
+    /**
+     * Default constructor.
+     *
+     * @param vnc        the configuration to use
+     * @param repository the git repository
+     * @param git        a git helper object built from the repository
+     * @param registrar  a storage for found/calculated metadata
+     */
+    public ScriptVersionStrategy(VersionNamingConfiguration vnc,
+                                 Repository repository,
+                                 Git git,
+                                 MetadataRegistrar registrar) {
+
+        super(vnc, repository, git, registrar);
+    }
+
+    @Override
+    public Version build(Commit head, List<Commit> parents) throws VersionCalculationException {
+        try {
+            final Commit base = findVersionCommit(head, parents);
+            final MetadataRegistrar registrar = getRegistrar();
+            final MetadataProvider metaProvider =
+                MetadataProvider.class.cast(registrar);
+
+            final HashMap<String, Object> metaProps =
+                new HashMap<String, Object>();
+
+            EnumSet.allOf(Metadatas.class).
+                forEach(key -> metaProvider.meta(key).
+                        ifPresent(value -> metaProps.put(key.name(), value)));
+
+            // Distance
+            registrar.registerMetadata(Metadatas.COMMIT_DISTANCE,
+                                       "" + base.getHeadDistance());
+
+            metaProps.put(Metadatas.COMMIT_DISTANCE.name(),
+                          base.getHeadDistance());
+
+            if (Features.DISTANCE_TO_ROOT.isActive()) {
+                final int dtr = GitUtils.
+                    distanceToRoot(getRepository(), head.getGitObject());
+
+                registrar.registerMetadata(Metadatas.COMMIT_DISTANCE_TO_ROOT, "" + dtr);
+
+                metaProps.put(Metadatas.COMMIT_DISTANCE_TO_ROOT.name(), dtr);
+            }
+
+            // Branch related
+            final String branch = getRepository().getBranch();
+
+            metaProps.put(Metadatas.BRANCH_NAME.name(), branch);
+
+            getVersionNamingConfiguration().branchQualifier(branch).
+                ifPresent(qualifier ->
+                          metaProps.put(Metadatas.QUALIFIED_BRANCH_NAME.name(),
+                                        qualifier));
+
+            GitUtils.providedBranchName().ifPresent(externalName -> {
+                    metaProps.put(Metadatas.QUALIFIED_BRANCH_NAME.name(),
+                                  externalName);
+                
+                    metaProps.put("PROVIDED_BRANCH_NAME", externalName);
+                });
+
+            try (final RevWalk walk = new RevWalk(getRepository())) {
+                final RevCommit rc = walk.parseCommit(head.getGitObject());
+
+                metaProps.put(Metadatas.COMMIT_TIMESTAMP.name(), GitUtils.getTimestamp(rc.getAuthorIdent().getWhen().toInstant()));
+            }
+
+            // Extra convenient metadata
+            metaProps.put("DETACHED_HEAD",
+                          GitUtils.isDetachedHead(getRepository()));
+
+            metaProps.put("BASE_COMMIT_ON_HEAD",
+                          isBaseCommitOnHead(head, base));
+
+            // Tag related metadata
+            final Ref tagToUse = findTagToUse(head, base);
+
+            final Version baseVersion;
+
+            if (tagToUse != null) {
+                final String tagName = GitUtils.tagNameFromRef(tagToUse);
+                final TagType tagType = computeTagType(tagToUse, maxVersionTag(base.getAnnotatedTags()).orElse(null));
+
+                baseVersion = versionFromTag(tagToUse);
+
+                metaProps.put(Metadatas.BASE_TAG_TYPE.name(), tagType.name());
+                metaProps.put(Metadatas.BASE_TAG.name(), tagName);
+            } else {
+                baseVersion = Version.DEFAULT_VERSION;
+            }
+
+            metaProps.put(Metadatas.BASE_VERSION.name(), baseVersion);
+
+            // Required by provideNextVersionsMetadatas
+            registrar.registerMetadata(Metadatas.BASE_VERSION,
+                                       baseVersion.toString());
+
+            metaProps.put(Metadatas.CURRENT_VERSION_MAJOR.name(),
+                          baseVersion.getMajor());
+
+            metaProps.put(Metadatas.CURRENT_VERSION_MINOR.name(),
+                          baseVersion.getMinor());
+
+            metaProps.put(Metadatas.CURRENT_VERSION_PATCH.name(),
+                          baseVersion.getPatch());
+
+            metaProps.put("ANNOTATED", GitUtils.isAnnotated(tagToUse));
+
+            // ---
+
+            final HashMap<String, Object> globalVariables =
+                new HashMap<String, Object>();
+
+            globalVariables.put("env", System.getenv());
+            globalVariables.put("sys", System.getProperties());
+
+            globalVariables.put("metadata",
+                                Collections.unmodifiableMap(metaProps));
+
+            final ScriptInterpreter interpreter;
+
+
+            if (script == null || script.length() == 0) {
+                interpreter = new GroovyScriptInterpreter();
+
+                final String sep = System.lineSeparator();
+
+                try (final InputStream in = getClass().getResourceAsStream("/META-INF/jgitver-version-script.groovy");
+                     final BufferedReader br =
+                         new BufferedReader(new InputStreamReader(in))) {
+
+                    final StringBuilder buf = new StringBuilder();
+
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        buf.append(line + sep);
+                    }
+
+                    script = buf.toString();
+                }
+            } else {
+                interpreter = (scriptType == ScriptType.BEAN_SHELL)
+                    ? new BeanShellScriptInterpreter()
+                    : new GroovyScriptInterpreter();
+            }
+
+            final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+            interpreter.evaluateScript(script,
+                                       Collections.emptyList(),
+                                       globalVariables,
+                                       new java.io.PrintStream(output));
+
+            final String csvResult = output.toString();
+
+            final String[] verComponents = csvResult.split(";");
+
+            if (verComponents.length < 3) {
+                throw new VersionCalculationException("invalid script result; expect at least 3 CSV columns (<major>;<minor>;<patch>): " + csvResult);
+            }
+
+            // ---
+
+            final int major;
+            final int minor;
+            final int patch;
+
+            try {
+                major = Integer.parseInt(verComponents[0]);
+            } catch (Exception cause) {
+                throw new VersionCalculationException("invalid major", cause);
+            }
+
+            try {
+                minor = Integer.parseInt(verComponents[1]);
+            } catch (Exception cause) {
+                throw new VersionCalculationException("invalid minor", cause);
+            }
+
+            try {
+                patch = Integer.parseInt(verComponents[2]);
+            } catch (Exception cause) {
+                throw new VersionCalculationException("invalid patch", cause);
+            }
+
+            // ---
+
+            final int qualifierCount = verComponents.length - 3;
+            final String[] qualifiers;
+
+            if (qualifierCount == 0) {
+                qualifiers = new String[0];
+            } else {
+                qualifiers = new String[qualifierCount];
+
+                System.arraycopy(verComponents, 3,
+                                 qualifiers, 0, qualifierCount);
+
+            }
+
+            return new Version(major, minor, patch, qualifiers);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+
+            throw new VersionCalculationException("cannot compute version", ex);
+        }
+    }
+
+    /**
+     * Set the type of the script (default: {@link ScriptType#GROOVY}).
+     * @param scriptType the script type
+     * @return itself for chaining
+     */
+    public ScriptVersionStrategy setScriptType(ScriptType scriptType) {
+        return runAndGetSelf(() -> this.scriptType = scriptType);
+    }
+
+    /**
+     * Set the script to be interpreted.
+     * @param script the script content
+     * @return itself for chaining
+     */
+    public ScriptVersionStrategy setScript(String script) {
+        return runAndGetSelf(() -> this.script = script);
+    }
+}

--- a/src/main/resources/META-INF/jgitver-version-script.groovy
+++ b/src/main/resources/META-INF/jgitver-version-script.groovy
@@ -1,0 +1,24 @@
+def currentPatch = metadata.CURRENT_VERSION_PATCH
+
+// autoIncrementPatch by default
+def patch = (metadata.BASE_COMMIT_ON_HEAD && metadata.ANNOTATE) ? currentPatch + 1 : currentPatch
+
+def mmp = metadata.CURRENT_VERSION_MAJOR + ';' + metadata.CURRENT_VERSION_MINOR + ';' + patch
+
+def qualifiers = []
+
+if (!metadata.DETACHED_HEAD && metadata.QUALIFIED_BRANCH_NAME) {
+  qualifiers.add(metadata.QUALIFIED_BRANCH_NAME)
+}
+
+if (!metadata.BASE_COMMIT_ON_HEAD || !metadata.ANNOTATED) {
+  def sz = qualifiers.size()
+
+  if (sz == 0) {
+    qualifiers.add(metadata.COMMIT_DISTANCE)
+  } else {
+    qualifiers[sz-1] = qualifiers[sz-1] + '.' + metadata.COMMIT_DISTANCE
+  }
+}
+
+print mmp + ';' + qualifiers.join(';')

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario10WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario10WithDefaultsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario10WithDefaultsTest extends ScenarioTest {
+
+    public Scenario10WithDefaultsTest() {
+        super(
+                Scenarios::s10_one_commit_no_tag_repository,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("1.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("0.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("0.0.1"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario11WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario11WithDefaultsTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario11WithDefaultsTest extends ScenarioTest {
+
+    public Scenario11WithDefaultsTest() {
+        super(
+                Scenarios::s11_linear_no_tag_repository,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId aCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(aCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+    
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-2"));
+    }
+
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-2"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("1.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("0.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("0.0.1"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario12WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario12WithDefaultsTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario12WithDefaultsTest extends ScenarioTest {
+
+    public Scenario12WithDefaultsTest() {
+        super(
+                Scenarios::s12_linear_with_RC_tags,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId aCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(aCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-0"));
+    }
+    
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    @Test @Disabled
+    public void version_of_D_commit() {
+        ObjectId dCommit = scenario.getCommits().get("D");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(dCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_E_commit() {
+        ObjectId eCommit = scenario.getCommits().get("E");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(eCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    @Test @Disabled
+    public void version_of_F_commit() {
+        ObjectId fCommit = scenario.getCommits().get("F");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(fCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_G_commit() {
+        ObjectId gCommit = scenario.getCommits().get("G");
+        
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(gCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    @Test
+    public void version_of_tag_1_0_0() {
+        unchecked(() -> git.checkout().setName("1.0.0").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("2.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("1.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("1.0.1"));
+    }
+    
+    @Test
+    public void version_of_master_in_dirty_state() throws IOException {
+        File dirtyFile = null;
+        try {
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName("master").call());
+            dirtyFile = scenario.makeDirty();
+            assertThat(versionCalculator.getVersion(), is("2.0.0-0"));
+            versionCalculator.setUseDirty(true);
+            assertThat(versionCalculator.getVersion(), is("2.0.0-0"));
+        } finally {
+            if (dirtyFile != null) {
+                dirtyFile.delete();
+            }
+        }
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario1WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario1WithDefaultsTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import fr.brouillard.oss.jgitver.Features;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario1WithDefaultsTest extends ScenarioTest {
+
+    public Scenario1WithDefaultsTest() {
+        super(
+                Scenarios::s1_linear_with_only_annotated_tags,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @BeforeAll
+    public static void activateTestFeatures() {
+        Features.DISTANCE_TO_ROOT.activate();
+    }
+
+    @BeforeAll
+    public static void resetTestFeatures() {
+        Features.DISTANCE_TO_ROOT.deactivate();
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+    
+    @Test
+    public void version_on_normal_tag_is_tag_value() {
+        Arrays.asList("1.0.0", "2.0.0").forEach(tag -> {
+            // when tag is checkout
+            unchecked(() -> git.checkout().setName(tag).call());
+            // the version matches the tag
+            assertThat(versionCalculator.getVersion(), is(tag));
+        });
+    }
+    
+    @Test
+    public void version_of_A_commit() {
+        ObjectId cCommit = scenario.getCommits().get("A");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+    
+    @Test
+    public void version_of_B_commit() {
+        ObjectId cCommit = scenario.getCommits().get("B");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_D_commit() {
+        ObjectId cCommit = scenario.getCommits().get("D");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+    
+    @Test
+    public void version_of_E_commit() {
+        ObjectId cCommit = scenario.getCommits().get("E");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("3.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("2.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("2.0.1"));
+    }
+
+    @Test
+    public void check_distances_on_master() {
+        unchecked(() -> git.checkout().setName("master").call());
+
+        assertThat(versionCalculator.getVersion(true), is("2.0.0-1"));
+
+        assertThat(versionCalculator.meta(Metadatas.COMMIT_DISTANCE).get(), is("1"));
+        assertThat(versionCalculator.meta(Metadatas.COMMIT_DISTANCE_TO_ROOT).get(), is("4"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario2WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario2WithDefaultsTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario2WithDefaultsTest extends ScenarioTest {
+
+    public Scenario2WithDefaultsTest() {
+        super(
+                Scenarios::s2_linear_with_both_tags,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+
+    @Test
+    public void version_of_B() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-1"));
+    }
+
+    @Test
+    public void version_of_D_commit() {
+        ObjectId cCommit = scenario.getCommits().get("D");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+
+    @Test
+    public void version_of_E_commit() {
+        ObjectId cCommit = scenario.getCommits().get("E");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+    }
+
+    @Test
+    public void version_of_annotated_tags() {
+        Arrays.asList("1.0.0", "2.0.0").forEach(tag -> {
+            // when tag is checkout
+            unchecked(() -> git.checkout().setName(tag).call());
+            // the version matches the tag
+            assertThat(versionCalculator.getVersion(), is(tag));
+        });
+    }
+
+    @Test
+    public void version_of_light_1_1_0() {
+        // we checkout light tag 1.1.0
+        unchecked(() -> git.checkout().setName("1.1.0").call());
+        // which is on a commit with annotated tag 1.0.0
+        // that must have precedence
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("3.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("2.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("2.0.1"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario3WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario3WithDefaultsTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario3WithDefaultsTest extends ScenarioTest {
+
+    public Scenario3WithDefaultsTest() {
+        super(
+                Scenarios::s3_linear_with_snapshots_light_tags,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-1"));
+    }
+
+    @Test
+    public void version_of_D_commit() {
+        ObjectId dCommit = scenario.getCommits().get("D");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(dCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+
+    @Test
+    public void version_of_E_commit() {
+        ObjectId eCommit = scenario.getCommits().get("E");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(eCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("3.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_F_commit() {
+        ObjectId fCommit = scenario.getCommits().get("F");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(fCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("3.0.0-2"));
+    }
+
+    @Test
+    public void version_of_annotated_tags() {
+        Arrays.asList("1.0.0", "2.0.0").forEach(tag -> {
+            // when tag is checkout
+            unchecked(() -> git.checkout().setName(tag).call());
+            // the version matches the tag
+            assertThat(versionCalculator.getVersion(), is(tag));
+        });
+    }
+
+    @Test
+    public void version_of_light_1_1_0_Snapshot() {
+        // we checkout light tag 1.1.0
+        unchecked(() -> git.checkout().setName("1.1.0-SNAPSHOT").call());
+        // which is on a commit with annotated tag 1.0.0 that has precedence
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    @Test
+    public void version_of_light_3_0_0_Snapshot() {
+        // we checkout light tag 1.1.0
+        unchecked(() -> git.checkout().setName("3.0.0-SNAPSHOT").call());
+        // which is on a commit with annotated tag 1.0.0
+        // that must have precedence
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("3.0.0-2"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("3.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("3.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("3.0.0"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario4WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario4WithDefaultsTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario4WithDefaultsTest extends ScenarioTest {
+
+    public Scenario4WithDefaultsTest() {
+        super(
+                Scenarios::s4_linear_with_only_annotated_tags_and_branch,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+
+    @Test
+    public void version_of_D_commit() {
+        ObjectId dCommit = scenario.getCommits().get("D");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(dCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+
+    @Test
+    public void version_of_E_commit() {
+        ObjectId eCommit = scenario.getCommits().get("E");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(eCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+    }
+    
+    @Test
+    public void version_of_F_commit() {
+        ObjectId fCommit = scenario.getCommits().get("F");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(fCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-2"));
+    }
+    
+    @Test
+    public void version_of_G_commit() {
+        ObjectId gCommit = scenario.getCommits().get("G");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(gCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-3"));
+    }
+
+    @Test
+    public void version_of_annotated_tags() {
+        Arrays.asList("1.0.0", "2.0.0").forEach(tag -> {
+            // when tag is checkout
+            unchecked(() -> git.checkout().setName(tag).call());
+            // the version matches the tag
+            assertThat(versionCalculator.getVersion(), is(tag));
+        });
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("3.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("2.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("2.0.1"));
+    }
+    
+    @Test
+    public void version_of_branch_issue_10() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("issue-10").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-issue_10.3"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario5WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario5WithDefaultsTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario5WithDefaultsTest extends ScenarioTest {
+
+    public Scenario5WithDefaultsTest() {
+        super(
+                Scenarios::s5_several_branches,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+
+    @Test
+    public void version_of_D_commit() {
+        ObjectId dCommit = scenario.getCommits().get("D");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(dCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+
+    @Test
+    public void version_of_annotated_tags() {
+        Arrays.asList("1.0.0").forEach(tag -> {
+            // when tag is checkout
+            unchecked(() -> git.checkout().setName(tag).call());
+            // the version matches the tag
+            assertThat(versionCalculator.getVersion(), is(tag));
+        });
+    }
+
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("2.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("1.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("1.0.1"));
+    }
+
+    @Test
+    public void version_of_branch_int() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("int").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-int.1"));
+    }
+
+    @Test
+    public void issue35_meta_contain_qualified_branch_name() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("int").call());
+        assertNotNull(versionCalculator.getVersionObject());
+        assertThat(versionCalculator.meta(Metadatas.QUALIFIED_BRANCH_NAME).get(), is("int"));
+    }
+
+    @Test
+    public void version_of_branch_dev() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("dev").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-dev.1"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario6WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario6WithDefaultsTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario6WithDefaultsTest extends ScenarioTest {
+
+    public Scenario6WithDefaultsTest() {
+        super(
+                Scenarios::s6_matching_and_non_matching_versions_tags,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+
+    @Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+    }
+
+    @Test
+    public void version_of_D_commit() {
+        ObjectId dCommit = scenario.getCommits().get("D");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(dCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-2"));
+    }
+    
+    @Test
+    public void version_of_E_commit() {
+        ObjectId eCommit = scenario.getCommits().get("E");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(eCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-3"));
+    }
+
+    @Test
+    public void version_of_annotated_tags() {
+        unchecked(() -> git.checkout().setName("1.0").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+        
+        unchecked(() -> git.checkout().setName("v2.0").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-3"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("3.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("2.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("2.0.1"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario8WithDefaultsTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/defaults/Scenario8WithDefaultsTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.defaults;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+
+public class Scenario8WithDefaultsTest extends ScenarioTest {
+
+    public Scenario8WithDefaultsTest() {
+        super(
+                Scenarios::s8_main_and_branch_with_intermediate_light_tag,
+                calculator -> calculator.setStrategy(Strategies.SCRIPT));
+    }
+
+    //@Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+
+    //@Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+    }
+
+    //@Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    //@Test
+    public void version_of_C_commit() {
+        ObjectId cCommit = scenario.getCommits().get("C");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(cCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+    }
+
+    //@Test
+    public void version_of_D_commit() {
+        ObjectId dCommit = scenario.getCommits().get("D");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(dCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-0"));
+    }
+    
+    //@Test
+    public void version_of_E_commit() {
+        ObjectId eCommit = scenario.getCommits().get("E");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(eCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-1"));
+    }
+    
+    //@Test
+    public void version_of_F_commit() {
+        ObjectId fCommit = scenario.getCommits().get("F");
+        
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(fCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-2"));
+    }
+
+    //@Test
+    public void version_of_annotated_tags() {
+        unchecked(() -> git.checkout().setName("1.0.0").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+    
+    //@Test
+    public void version_of_light_tag_1_1_0() {
+        unchecked(() -> git.checkout().setName("1.1.0").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-0"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-1"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("2.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("1.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("1.1.0"));
+    }
+    
+    //@Test
+    public void version_of_branch_issue_10() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("issue-10").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-issue_10.2"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/script/others/ScenarioWithSnapshotTest.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/script/others/ScenarioWithSnapshotTest.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.script.others;
+
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.impl.VersionCalculationException;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ScenarioWithSnapshotTest {
+
+    @Nested
+    class InvalidVersion1 extends ScenarioTest {
+        InvalidVersion1() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT)
+                    .setScript("print '1'")); // Only major
+        }
+
+        @Test
+        void should_fail() {
+            final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(exception.getCause(), instanceOf(VersionCalculationException.class));
+        }
+
+    }
+
+    @Nested
+    class InvalidVersion12 extends ScenarioTest {
+        InvalidVersion12() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT)
+                            .setScript("print '1;2'")); // Missing patch
+        }
+
+        @Test
+        void should_fail() {
+            final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(exception.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+
+    @Nested
+    class InvalidVersionA00 extends ScenarioTest {
+        InvalidVersionA00() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT)
+                            .setScript("print 'A;0;0'")); // Missing patch
+        }
+
+        @Test
+        void should_fail() {
+            final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(exception.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+
+    @Nested
+    class InvalidVersion1B0 extends ScenarioTest {
+        InvalidVersion1B0() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT)
+                            .setScript("print '1;B;0'")); // Missing patch
+        }
+
+        @Test
+        void should_fail() {
+            final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(exception.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+
+    @Nested
+    class InvalidVersion12C extends ScenarioTest {
+        InvalidVersion12C() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT)
+                            .setScript("print '1;2;C'")); // Missing patch
+        }
+
+        @Test
+        void should_fail() {
+            final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(exception.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+
+    @Nested
+    class InvalidVersionScript extends ScenarioTest {
+        InvalidVersionScript() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT)
+                            .setScript("invalid; print '1;0;0'"));
+        }
+
+        @Test
+        void should_fail() {
+            final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> versionCalculator.getVersion());
+
+            assertThat(exception.getCause(), instanceOf(VersionCalculationException.class));
+        }
+    }
+
+    @Nested
+    class MetadataQualifiers extends ScenarioTest {
+        private static final String s =
+            "print '1;2;3;'"
+            + " + metadata.CURRENT_VERSION_MAJOR + ';'"
+            + " + metadata.HEAD_TAGS + ';'"
+            + " + metadata.QUALIFIED_BRANCH_NAME + ';'"
+            + " + metadata.DIRTY + ';'"
+            + " + metadata.COMMIT_DISTANCE + ';'";
+
+        MetadataQualifiers() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT).setScript(s));
+        }
+
+        @Test
+        void foo() {
+            assertThat(versionCalculator.getVersion(),
+                       is("1.2.3-2--null-false-1"));
+        }
+    }
+
+    @Nested
+    class Scenario1 extends ScenarioTest {
+        private static final String s =
+            "def qualifiers = [];" +
+            "if (!metadata.HEAD_TAGS) {" +
+            "  qualifiers.add(metadata.COMMIT_DISTANCE)" +
+            "};" +
+            "print"
+            + " metadata.CURRENT_VERSION_MAJOR + ';'"
+            + "+ metadata.CURRENT_VERSION_MINOR + ';'"
+            + "+ metadata.CURRENT_VERSION_PATCH + ';'"
+            + "+ qualifiers.join(';')";
+
+        /**
+         * Builds the following repository
+         * <pre>
+         * $ git log --graph --abbrev-commit --decorate --format=format:'%h - (%ar) %s - %an %d'
+         * * 80eee6d - (18 seconds ago) content E - Matthieu Brouillard (HEAD -> master)
+         * * 98358d0 - (18 seconds ago) content D - Matthieu Brouillard (tag: 2.0.0)
+         * * 00a993e - (18 seconds ago) content C - Matthieu Brouillard
+         * * 183ccc6 - (18 seconds ago) content B - Matthieu Brouillard (tag: 1.0.0)
+         * * b048402 - (18 seconds ago) content A - Matthieu Brouillard
+         * </pre>
+         * @return the scenario object corresponding to the above git repository
+         */
+        Scenario1() {
+            super(
+                    Scenarios::s1_linear_with_only_annotated_tags,
+                    calculator -> calculator
+                            .setStrategy(Strategies.SCRIPT).setScript(s));
+        }
+
+        @Test
+        void head_is_on_master_by_default() throws Exception {
+            assertThat(repository.getBranch(), is("master"));
+        }
+
+        @Test
+        void version_on_normal_tag_is_tag_value() {
+            Arrays.asList("1.0.0", "2.0.0").forEach(tag -> {
+                // when tag is checkout
+                unchecked(() -> git.checkout().setName(tag).call());
+                // the version matches the tag
+                assertThat(versionCalculator.getVersion(), is(tag));
+            });
+        }
+
+        @Test
+        void version_of_A_commit() {
+            ObjectId cCommit = scenario.getCommits().get("A");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(cCommit.name()).call());
+            assertThat(versionCalculator.getVersion(), is("0.0.0-0"));
+        }
+
+        @Test
+        void version_of_B_commit() {
+            ObjectId cCommit = scenario.getCommits().get("B");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(cCommit.name()).call());
+            assertThat(versionCalculator.getVersion(), is("1.0.0"));
+        }
+
+        @Test
+        void version_of_C_commit() {
+            ObjectId cCommit = scenario.getCommits().get("C");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(cCommit.name()).call());
+            assertThat(versionCalculator.getVersion(), is("1.0.0-1"));
+        }
+
+        @Test
+        void version_of_D_commit() {
+            ObjectId cCommit = scenario.getCommits().get("D");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(cCommit.name()).call());
+            assertThat(versionCalculator.getVersion(), is("2.0.0"));
+        }
+
+        @Test
+        void version_of_E_commit() {
+            ObjectId cCommit = scenario.getCommits().get("E");
+
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName(cCommit.name()).call());
+            assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+        }
+
+        @Test
+        void version_of_master() {
+            // checkout the commit in scenario
+            unchecked(() -> git.checkout().setName("master").call());
+            assertThat(versionCalculator.getVersion(), is("2.0.0-1"));
+
+            assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("3.0.0"));
+            assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("2.1.0"));
+            assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("2.0.1"));
+        }
+    }
+}


### PR DESCRIPTION
Executes the given script (according its `ScriptType`, default being `ScriptType.GROOVY`) and use the script output as version.

This output must be in CSV format using ';' separator, with at least the 3 first columns, corresponding to integer values for major, minor and patch (e.g. `1;2;3`).

The script has access to [metadata](https://jgitver.github.io/#_meta_fields) (e.g. In BeanShell for the SHA1 `metadata.GIT_SHA1_8`).

The script also has access to the environment variables and system properties, respectively thanks to `env` (e.g. `env.HOME`) and <tt>sys</tt> (e.g. `sys.user.home`).

If no script is passed as parameter then the [default one is used](https://github.com/jgitver/jgitver/pull/108/files#diff-a1e4def6be0c6b02c19ac43d538da595), with the same behavior as the `PATTERN` strategy.

Also allow to implement conditional versioning #81 , e.g.

```xml
<configuration xmlns="http://jgitver.github.io/maven/configuration/1.1.0"
	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	    xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
  <strategy>SCRIPT</strategy>
  <script><![CDATA[
major = metadata.CURRENT_VERSION_MAJOR
minor = metadata.CURRENT_VERSION_MINOR
patch = metadata.CURRENT_VERSION_PATCH

def qualifiers = []

if (!metadata.HEAD_TAGS) {
  qualifiers.add('SNAPSHOT')

  if (major == 0 && minor == 0 && patch == 0) {
    major = 1 // Defaults to 1.0.0
  } else if (metadata.BRANCH_NAME.startsWith("release/")) {
    patch++
  } else {
    minor++
  }
}

print major + ';' + minor + ';' + patch + ';' + qualifiers.join(';')
]]></script>
</configuration>
```

> Would require to update the maven plugin as for configuration: https://github.com/jgitver/jgitver-maven-plugin/pull/136