### PR TITLE
Add version pattern on branchingPolicies

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
@@ -34,6 +34,8 @@ import fr.brouillard.oss.jgitver.metadata.MetadataProvider;
 import fr.brouillard.oss.jgitver.metadata.MetadataRegistrar;
 import fr.brouillard.oss.jgitver.metadata.Metadatas;
 
+import static java.util.Optional.empty;
+
 public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrategy> {
     public static final String DEFAULT_VERSION_PATTERN = "${v}${<meta.QUALIFIED_BRANCH_NAME}${<meta.COMMIT_DISTANCE}";
     public static final String DEFAULT_TAG_VERSION_PATTERN = "${v}";
@@ -59,8 +61,8 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
         try {
             Commit base = findVersionCommit(head, parents);
             Ref tagToUse = findTagToUse(head, base);
-            Version baseVersion = getBaseVersionAndRegisterMetadata(base,tagToUse);
-
+            Version baseVersion = getBaseVersionAndRegisterMetadata(base, tagToUse);
+            Optional<String> branchPattern = empty();
             if (!isBaseCommitOnHead(head, base) && autoIncrementPatch) {
                 // we are not on head
                 if (GitUtils.isAnnotated(tagToUse)) {
@@ -87,6 +89,7 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
             if (!GitUtils.isDetachedHead(getRepository())) {
                 String branch = getRepository().getBranch();
                 baseVersion = enhanceVersionWithBranch(baseVersion, branch);
+                branchPattern = getVersionNamingConfiguration().branchPattern(branch);
             } else {
                 // ugly syntax to bypass the final/effectively final pb to access vraiable in lambda
                 Optional<String> externalyProvidedBranchName = GitUtils.providedBranchName();
@@ -95,7 +98,8 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
                 }
             }
 
-            String versionPattern = (this.versionPattern != null) ? this.versionPattern : DEFAULT_VERSION_PATTERN;
+
+            String versionPattern = resolveVersionPattern(branchPattern);
             if (isBaseCommitOnHead(head, base) && GitUtils.isAnnotated(tagToUse)) {
                 versionPattern = (this.tagVersionPattern != null) ? this.tagVersionPattern : DEFAULT_TAG_VERSION_PATTERN;
             }
@@ -119,6 +123,10 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
         } catch (Exception ex) {
             throw new VersionCalculationException("cannot compute version", ex);
         }
+    }
+
+    private String resolveVersionPattern(Optional<String> branchPattern) {
+        return branchPattern.orElse(this.versionPattern != null ? this.versionPattern : DEFAULT_VERSION_PATTERN);
     }
 
     /**

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/VersionNamingConfiguration.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/VersionNamingConfiguration.java
@@ -76,7 +76,15 @@ public class VersionNamingConfiguration {
                 return bPolicy.qualifier(branch);
             }
         }
-        
+        return Optional.empty();
+    }
+
+    public Optional<String> branchPattern(String branch) {
+        for (BranchingPolicy bPolicy : branchPolicies) {
+            if (bPolicy.appliesOn(branch)) {
+                return bPolicy.getVersionPattern();
+            }
+        }
         return Optional.empty();
     }
 }

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario5WithBranchPattern.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario5WithBranchPattern.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.pattern.others;
+
+import fr.brouillard.oss.jgitver.BranchingPolicy;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Scenario5WithBranchPattern extends ScenarioTest {
+
+    public Scenario5WithBranchPattern() {
+        super(
+                Scenarios::s5_several_branches,
+                calculator -> calculator.setStrategy(Strategies.PATTERN)
+                        .setVersionPattern("${v}-DEFAULT")
+                        .setQualifierBranchingPolicies(new BranchingPolicy("(int)", "${v}-INT")));
+    }
+
+    @Test
+    public void version_of_branch_master() {
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-DEFAULT"));
+    }
+
+    @Test
+    public void version_of_branch_int() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("int").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-INT"));
+    }
+
+    @Test
+    public void version_of_branch_dev() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("dev").call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-DEFAULT"));
+    }
+
+    @Test
+    public void version_of_A_commit() {
+        ObjectId firstCommit = scenario.getCommits().get("A");
+
+        // checkout the first commit in scenario
+        unchecked(() -> git.checkout().setName(firstCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void version_of_B_commit() {
+        ObjectId bCommit = scenario.getCommits().get("B");
+
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName(bCommit.name()).call());
+        assertThat(versionCalculator.getVersion(), is("1.0.0-DEFAULT"));
+    }
+}


### PR DESCRIPTION
Add customizable patterns on branching policies.

This will allow us to create a custom pattern on release branches for git-flow.

fix #81

If this PR is ok I can do the update on maven and Gradle plugins.