### PR TITLE
Add COMMIT_ISO_TIMESTAMP metadata compatible with ISO format in UTC timezone

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/impl/ConfigurableVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/ConfigurableVersionStrategy.java
@@ -117,6 +117,8 @@ public class ConfigurableVersionStrategy extends VersionStrategy<ConfigurableVer
                 RevCommit rc = walk.parseCommit(head.getGitObject());
                 String commitTimestamp = GitUtils.getTimestamp(rc.getAuthorIdent().getWhen().toInstant());
                 getRegistrar().registerMetadata(Metadatas.COMMIT_TIMESTAMP, commitTimestamp);
+                String isoCommitTimestamp = GitUtils.getIsoTimestamp(rc.getAuthorIdent().getWhen().toInstant());
+                getRegistrar().registerMetadata(Metadatas.COMMIT_ISO_TIMESTAMP, isoCommitTimestamp);
                 if (needsCommitTimestamp) {
                     baseVersion = baseVersion.addQualifier(commitTimestamp);
                 }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/GitUtils.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/GitUtils.java
@@ -18,6 +18,7 @@ package fr.brouillard.oss.jgitver.impl;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
@@ -85,6 +86,17 @@ public class GitUtils {
                 .replace("-", "")
                 .replace(":", "")
                 .replace("T", "");
+    }
+
+    /**
+     * Builds a string representing the given instant interpolated in the UTC timezone.
+     * @param commitInstant commit time as an Instant
+     * @return a string representing the commit time in ISO format in UTC timezone
+     */
+    public static String getIsoTimestamp(Instant commitInstant) {
+    	OffsetDateTime commitDateTime = OffsetDateTime.ofInstant(commitInstant, ZoneId.of("Z"));
+        String isoDateTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(commitDateTime);
+        return isoDateTime;
     }
 
     /**

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/MavenVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/MavenVersionStrategy.java
@@ -88,6 +88,8 @@ public class MavenVersionStrategy extends VersionStrategy<MavenVersionStrategy> 
                 RevCommit rc = walk.parseCommit(head.getGitObject());
                 String commitTimestamp = GitUtils.getTimestamp(rc.getAuthorIdent().getWhen().toInstant());
                 getRegistrar().registerMetadata(Metadatas.COMMIT_TIMESTAMP, commitTimestamp);
+                String isoCommitTimestamp = GitUtils.getIsoTimestamp(rc.getAuthorIdent().getWhen().toInstant());
+                getRegistrar().registerMetadata(Metadatas.COMMIT_ISO_TIMESTAMP, isoCommitTimestamp);
             }
             
             return needSnapshot ? baseVersion.removeQualifier("SNAPSHOT").addQualifier("SNAPSHOT") : baseVersion;

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
@@ -83,6 +83,8 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
                 RevCommit rc = walk.parseCommit(head.getGitObject());
                 String commitTimestamp = GitUtils.getTimestamp(rc.getAuthorIdent().getWhen().toInstant());
                 getRegistrar().registerMetadata(Metadatas.COMMIT_TIMESTAMP, commitTimestamp);
+                String isoCommitTimestamp = GitUtils.getIsoTimestamp(rc.getAuthorIdent().getWhen().toInstant());
+                getRegistrar().registerMetadata(Metadatas.COMMIT_ISO_TIMESTAMP, isoCommitTimestamp);
                 baseVersion = baseVersion.addQualifier(commitTimestamp);
             }
 

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/ScriptVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/ScriptVersionStrategy.java
@@ -123,6 +123,8 @@ public class ScriptVersionStrategy extends VersionStrategy<ScriptVersionStrategy
             try (final RevWalk walk = new RevWalk(getRepository())) {
                 final RevCommit rc = walk.parseCommit(head.getGitObject());
                 getRegistrar().registerMetadata(Metadatas.COMMIT_TIMESTAMP, GitUtils.getTimestamp(rc.getAuthorIdent().getWhen().toInstant()));
+                String isoCommitTimestamp = GitUtils.getIsoTimestamp(rc.getAuthorIdent().getWhen().toInstant());
+                getRegistrar().registerMetadata(Metadatas.COMMIT_ISO_TIMESTAMP, isoCommitTimestamp);
             }
 
             registrar.registerMetadata(Metadatas.BASE_COMMIT_ON_HEAD, "" + isBaseCommitOnHead(head, base));

--- a/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java
@@ -168,6 +168,11 @@ public enum Metadatas {
      */
     COMMIT_TIMESTAMP,
     /**
+     * Exposes the commit timestamp instant in the UTC timezone using
+     * DateTimeFormatter.ISO_OFFSET_DATE_TIME
+     */
+    COMMIT_ISO_TIMESTAMP,
+    /**
      * True if the current HEAD is on an annotated tag, false otherwise
      */
     ANNOTATED,


### PR DESCRIPTION
Prerequisite to using COMMIT_ISO_TIMESTAMP through jgit-maven-plugin as project.build.outputTimestamp for reproducible build https://maven.apache.org/guides/mini/guide-reproducible-builds.html