### PR TITLE
Fixes NEAREST lookup policy /w lightweight tags

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
@@ -461,9 +461,7 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
                     // we take the most recent one among those at the same distance
                     // due to https://github.com/jgitver/jgitver/issues/73
                     // we need to keep only the annotated tags
-                    if (LookupPolicy.LATEST.equals(lookupPolicy)) {
-                        tagsAtMinimumDistance = keepOnlyAnnotatedTags(tagsAtMinimumDistance);
-                    }
+                    tagsAtMinimumDistance = keepOnlyAnnotatedTags(tagsAtMinimumDistance);
                     return latestObjectIdOfTags(tagsAtMinimumDistance, refToObjectIdFunction);
                 }
             default:


### PR DESCRIPTION
It's not an ideal solution but otherwise it just crashes with an error identical to https://github.com/jgitver/jgitver/issues/73 if it tries to get the date on the nearest reachable lightweight tag