### PR TITLE
GH-72 Add autoIncrementMinor

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/GitVersionCalculator.java
@@ -126,6 +126,18 @@ public interface GitVersionCalculator extends AutoCloseable, MetadataProvider {
     GitVersionCalculator setAutoIncrementPatch(boolean value);
 
     /**
+     * When true, when the found tag to calculate a version for HEAD is a normal/annotated one, the semver minor version
+     * of the tag is increased by one and the patch version is set to 0 ;
+     * except when the tag is on the HEAD itself. This action is not in use if the
+     * SNAPSHOT qualifier is present on the found version or if the found tag is a lightweight one.
+     *
+     * @param value if true and when found tag is not on HEAD, then version returned will be the found version with
+     *        minor number increased by one and patch number set to 0. default false.
+     * @return itself to chain settings
+     */
+    GitVersionCalculator setAutoIncrementMinor(boolean value);
+
+    /**
      * Defines a comma separated list of branches for which no branch name qualifier will be used. default "master".
      * Example: "master, integration"
      * This method overrides the usage of {@link #setQualifierBranchingPolicies(List)} &amp;

--- a/src/main/java/fr/brouillard/oss/jgitver/cli/Options.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/cli/Options.java
@@ -38,6 +38,9 @@ public class Options {
     @Option(names = {"--autoIncrementPatch"}, description = "activate auto increment patch functionality")
     boolean autoIncrementPatch = true;
 
+    @Option(names = {"--autoIncrementMinor"}, description = "activate auto increment minor functionality")
+    boolean autoIncrementMinor = false;
+
     @Option(names = {"--useDistance"}, description = "activate distance qualifier")
     boolean useDistance = true;
 

--- a/src/main/java/fr/brouillard/oss/jgitver/cli/RunnableCLI.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/cli/RunnableCLI.java
@@ -77,6 +77,7 @@ public class RunnableCLI {
 
         gvc.setUseDistance(opts.useDistance);
         gvc.setAutoIncrementPatch(opts.autoIncrementPatch);
+        gvc.setAutoIncrementMinor(opts.autoIncrementMinor);
         gvc.setUseDirty(opts.useDirty);
         gvc.setForceComputation(opts.forceComputation);
         gvc.setUseLongFormat(opts.useLongFormat);

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/GitVersionCalculatorImpl.java
@@ -66,6 +66,7 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
     private Repository repository;
     private boolean mavenLike = false;
     private boolean autoIncrementPatch = false;
+    private boolean autoIncrementMinor = false;
     private boolean useDistance = true;
     private boolean useGitCommitId = false;
     private boolean useGitCommitTimestamp = false;
@@ -144,11 +145,13 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
                 case MAVEN:
                     strategy = new MavenVersionStrategy(vnc, repository, git, metadatas)
                             .setForceComputation(forceComputation)
+                            .setAutoIncrementMinor(autoIncrementMinor)
                             .setUseDirty(useDirty);
                     break;
                 case CONFIGURABLE:
                     strategy = new ConfigurableVersionStrategy(vnc, repository, git, metadatas)
                             .setAutoIncrementPatch(autoIncrementPatch)
+                            .setAutoIncrementMinor(autoIncrementMinor)
                             .setUseDistance(useDistance)
                             .setUseDirty(useDirty)
                             .setUseGitCommitId(useGitCommitId)
@@ -160,6 +163,7 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
                 case PATTERN:
                     strategy = new PatternVersionStrategy(vnc, repository, git, metadatas)
                             .setAutoIncrementPatch(autoIncrementPatch)
+                            .setAutoIncrementMinor(autoIncrementMinor)
                             .setVersionPattern(versionPattern)
                             .setTagVersionPattern(tagVersionPattern);
                     break;
@@ -228,7 +232,7 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
         if (Version.EMPTY_REPOSITORY_VERSION.equals(calculatedVersion)) {
             return false;
         }
-        return (autoIncrementPatch || strategy instanceof MavenVersionStrategy)
+        return (autoIncrementPatch || (strategy instanceof MavenVersionStrategy && !this.autoIncrementMinor))
                 && metadatas.meta(Metadatas.HEAD_VERSION_TAGS).get().isEmpty();
     }
 
@@ -262,6 +266,12 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
                             unqualifiedCalculatedVersion.getPatch() - 1
                     );
                 }
+            } else if (this.autoIncrementMinor && !unqualifiedCalculatedVersion.equals(unqualifiedBaseVersion)) {
+                unqualifiedCalculatedVersion = new Version(
+                        unqualifiedCalculatedVersion.getMajor(),
+                        unqualifiedCalculatedVersion.getMinor() - 1,
+                        unqualifiedCalculatedVersion.getPatch()
+                );
             }
 
             metadatas.registerMetadata(Metadatas.NEXT_MAJOR_VERSION, unqualifiedCalculatedVersion.incrementMajor().toString());
@@ -520,6 +530,12 @@ public class GitVersionCalculatorImpl implements GitVersionCalculator {
     @Override
     public GitVersionCalculator setAutoIncrementPatch(boolean value) {
         this.autoIncrementPatch = value;
+        return this;
+    }
+
+    @Override
+    public GitVersionCalculator setAutoIncrementMinor(boolean value) {
+        this.autoIncrementMinor = value;
         return this;
     }
 

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/MavenVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/MavenVersionStrategy.java
@@ -31,6 +31,7 @@ import fr.brouillard.oss.jgitver.metadata.Metadatas;
 public class MavenVersionStrategy extends VersionStrategy<MavenVersionStrategy> {
     private boolean useDirty = false;
     private boolean forceComputation = false;
+    private boolean autoIncrementMinor = false;
 
     public MavenVersionStrategy(VersionNamingConfiguration vnc, Repository repository, Git git, MetadataRegistrar metadatas) {
         super(vnc, repository, git, metadatas);
@@ -62,7 +63,7 @@ public class MavenVersionStrategy extends VersionStrategy<MavenVersionStrategy> 
                     // we are not on head
                     if (GitUtils.isAnnotated(tagToUse) && !baseVersion.removeQualifier("SNAPSHOT").isQualified()) {
                         // found tag to use was a non qualified annotated one, lets' increment the version automatically
-                        baseVersion = baseVersion.incrementPatch();
+                        baseVersion = incrementVersion(baseVersion);
                     }
                     baseVersion = baseVersion.noQualifier();
                 }
@@ -98,10 +99,19 @@ public class MavenVersionStrategy extends VersionStrategy<MavenVersionStrategy> 
         }
     }
 
+    private Version incrementVersion(Version baseVersion) {
+        return this.autoIncrementMinor ? baseVersion.incrementMinor() : baseVersion.incrementPatch();
+    }
+
     public MavenVersionStrategy setUseDirty(boolean useDirty) {
         return runAndGetSelf(() -> this.useDirty = useDirty);
     }
     public MavenVersionStrategy setForceComputation(boolean forceComputation) {
         return runAndGetSelf(() -> this.forceComputation = forceComputation);
+    }
+
+    public MavenVersionStrategy setAutoIncrementMinor(boolean autoIncrementMinor) {
+        this.autoIncrementMinor = autoIncrementMinor;
+        return this;
     }
 }

--- a/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/PatternVersionStrategy.java
@@ -43,6 +43,7 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
     private String versionPattern = null;
     private String tagVersionPattern = null;
     private boolean autoIncrementPatch = false;
+    private boolean autoIncrementMinor = false;
 
     /**
      * Default constructor.
@@ -63,11 +64,11 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
             Ref tagToUse = findTagToUse(head, base);
             Version baseVersion = getBaseVersionAndRegisterMetadata(base, tagToUse);
             Optional<String> branchPattern = empty();
-            if (!isBaseCommitOnHead(head, base) && autoIncrementPatch) {
+            if (!isBaseCommitOnHead(head, base) && (autoIncrementPatch || autoIncrementMinor)) {
                 // we are not on head
                 if (GitUtils.isAnnotated(tagToUse)) {
                     // found tag to use was an annotated one, lets' increment the version automatically
-                    baseVersion = baseVersion.incrementPatch();
+                    baseVersion = autoIncrementPatch ? baseVersion.incrementPatch() : baseVersion.incrementMinor();
                 }
             }
 
@@ -159,4 +160,7 @@ public class PatternVersionStrategy extends VersionStrategy<PatternVersionStrate
         return runAndGetSelf(() -> this.autoIncrementPatch = autoIncrementPatch);
     }
 
+    public PatternVersionStrategy setAutoIncrementMinor(boolean autoIncrementMinor) {
+        return runAndGetSelf(() -> this.autoIncrementMinor = autoIncrementMinor);
+    }
 }

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/configurable/others/Scenario13GitflowIncrementingMinor.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/configurable/others/Scenario13GitflowIncrementingMinor.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.configurable.others;
+
+import fr.brouillard.oss.jgitver.BranchingPolicy;
+import fr.brouillard.oss.jgitver.BranchingPolicy.BranchNameTransformations;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Scenario13GitflowIncrementingMinor extends ScenarioTest {
+
+    public Scenario13GitflowIncrementingMinor() {
+        super(
+                Scenarios::s13_gitflow,
+                calculator -> calculator
+                        .setStrategy(Strategies.CONFIGURABLE)
+                        .setAutoIncrementPatch(false)
+                        .setAutoIncrementMinor(true)
+                        .setQualifierBranchingPolicies(
+                                BranchingPolicy.ignoreBranchName("master"),
+                                BranchingPolicy.fixedBranchName("develop"),
+                                new BranchingPolicy("release/(.*)", Collections.singletonList(BranchNameTransformations.IGNORE.name())),
+                                new BranchingPolicy("feature/(.*)", Arrays.asList(
+                                        BranchNameTransformations.REMOVE_UNEXPECTED_CHARS.name(),
+                                        BranchNameTransformations.LOWERCASE_EN.name())
+                                )
+                        )
+                        .setUseDefaultBranchingPolicy(false));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("3.0.0"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("4.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("3.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("3.0.1"));
+    }
+    
+    @Test
+    public void version_of_branch_release_1x() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("release/1.x").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-2"));
+    }
+    
+    @Test
+    public void version_of_branch_release_2x() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("release/2.x").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-0"));
+    }
+    
+    @Test
+    public void version_of_branch_develop() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("develop").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-2-develop"));
+    }
+    
+    @Test
+    public void version_of_a_feature_branch() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-2-addsso"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/maven/others/Scenario13GitflowIncrementingMinor.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/maven/others/Scenario13GitflowIncrementingMinor.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.maven.others;
+
+import fr.brouillard.oss.jgitver.BranchingPolicy;
+import fr.brouillard.oss.jgitver.BranchingPolicy.BranchNameTransformations;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Scenario13GitflowIncrementingMinor extends ScenarioTest {
+
+    public Scenario13GitflowIncrementingMinor() {
+        super(
+                Scenarios::s13_gitflow,
+                calculator -> calculator
+                        .setStrategy(Strategies.MAVEN)
+                        .setAutoIncrementMinor(true)
+                        .setQualifierBranchingPolicies(
+                                BranchingPolicy.ignoreBranchName("master"),
+                                BranchingPolicy.fixedBranchName("develop"),
+                                new BranchingPolicy("release/(.*)", Collections.singletonList(BranchNameTransformations.IGNORE.name())),
+                                new BranchingPolicy("feature/(.*)", Arrays.asList(
+                                        BranchNameTransformations.REMOVE_UNEXPECTED_CHARS.name(),
+                                        BranchNameTransformations.LOWERCASE_EN.name())
+                                )
+                        )
+                        .setUseDefaultBranchingPolicy(false));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("3.0.0"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("4.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("3.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("3.0.1"));
+    }
+    
+    @Test
+    public void version_of_branch_release_1x() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("release/1.x").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-SNAPSHOT"));
+    }
+    
+    @Test
+    public void version_of_branch_release_2x() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("release/2.x").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-SNAPSHOT"));
+    }
+    
+    @Test
+    public void version_of_branch_develop() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("develop").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-develop-SNAPSHOT"));
+    }
+    
+    @Test
+    public void version_of_a_feature_branch() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-addsso-SNAPSHOT"));
+    }
+}

--- a/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario13GitflowIncrementingMinor.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/strategy/pattern/others/Scenario13GitflowIncrementingMinor.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.strategy.pattern.others;
+
+import fr.brouillard.oss.jgitver.BranchingPolicy;
+import fr.brouillard.oss.jgitver.BranchingPolicy.BranchNameTransformations;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static fr.brouillard.oss.jgitver.impl.Lambdas.unchecked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Scenario13GitflowIncrementingMinor extends ScenarioTest {
+
+    public Scenario13GitflowIncrementingMinor() {
+        super(
+                Scenarios::s13_gitflow,
+                calculator -> calculator
+                        .setStrategy(Strategies.PATTERN)
+                        .setAutoIncrementMinor(true)
+                        .setQualifierBranchingPolicies(
+                                BranchingPolicy.ignoreBranchName("master"),
+                                BranchingPolicy.fixedBranchName("develop"),
+                                new BranchingPolicy("release/(.*)", Collections.singletonList(BranchNameTransformations.IGNORE.name())),
+                                new BranchingPolicy("feature/(.*)", Arrays.asList(
+                                        BranchNameTransformations.REMOVE_UNEXPECTED_CHARS.name(),
+                                        BranchNameTransformations.LOWERCASE_EN.name())
+                                )
+                        )
+                        .setUseDefaultBranchingPolicy(false));
+    }
+
+    @Test
+    public void head_is_on_master_by_default() throws Exception {
+        assertThat(repository.getBranch(), is("master"));
+    }
+    
+    @Test
+    public void version_of_master() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("master").call());
+        assertThat(versionCalculator.getVersion(), is("3.0.0"));
+
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MAJOR_VERSION).get(), is("4.0.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_MINOR_VERSION).get(), is("3.1.0"));
+        assertThat(versionCalculator.meta(Metadatas.NEXT_PATCH_VERSION).get(), is("3.0.1"));
+    }
+    
+    @Test
+    public void version_of_branch_release_1x() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("release/1.x").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-2"));
+    }
+    
+    @Test
+    public void version_of_branch_release_2x() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("release/2.x").call());
+        assertThat(versionCalculator.getVersion(), is("2.0.0-0"));
+    }
+    
+    @Test
+    public void version_of_branch_develop() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("develop").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-develop.2"));
+    }
+    
+    @Test
+    public void version_of_a_feature_branch() {
+        // checkout the commit in scenario
+        unchecked(() -> git.checkout().setName("feature/add-sso").call());
+        assertThat(versionCalculator.getVersion(), is("1.1.0-addsso.2"));
+    }
+}


### PR DESCRIPTION
Hello, this is a proposal to add the capability of auto increasing the Minor version instead of the patch, as described in issue #72. 

I chose to keep the same criteria used for increasing the patch version in MAVEN, CONFIGURABLE and PATTERN strategies to minimize impact on existing code.

I've also created adaptations of the gitflow tests (scenario 13). There are 3 failing and 6 ignored preexisting tests that show the same behaviour in the master branch.

Please let me know if there's anything to be changed. Also, I can open the PRs for the plugins if necessary.

Thanks a lot for the great work!