### PR TITLE
Fix for Issue-137 (not all parents traversed)

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/impl/DistanceCalculator.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/impl/DistanceCalculator.java
@@ -198,20 +198,25 @@ public interface DistanceCalculator {
                         // we found it
                         return Optional.of(Integer.valueOf(commitCount));
                     }
-                    // get next head
+                    // get first parent
                     RevCommit firstParent = null;
-                    if (parents != null && parents.length > 0) {
-                        firstParent = parents[0];
+                    if (parents != null) {
+                        if (parents.length > 0) {
+                            firstParent = parents[0];
+                        }
+                        // remember other parents as we may need to follow the other parents as well if
+                        // the target is not on the current branch.
+                        for (int i = 1; i < parents.length; i++) {
+                            if (!processedRevs.contains(parents[i])) {
+                                parentsStack.push(Pair.of(commitCount, parents[i]));
+                            }
+                        }
                     }
+                    // get next head from first parent
                     if (firstParent != null && !processedRevs.contains(firstParent)) {
                         // follow the first parent but only if not yet processed for faster processing and to avoid loops
                         head = walk.parseCommit(firstParent);
                         processedRevs.add(firstParent);
-                        // remember other parents as we may need to follow the other parents as well if
-                        // the target is not on the current branch.
-                        for (int i = 1; i < parents.length; i++) {
-                            parentsStack.push(Pair.of(commitCount, parents[i]));
-                        }
                     } else {
                         // traverse next parent
                         Pair<Integer, RevCommit> previous = parentsStack.poll();

--- a/src/test/java/fr/brouillard/oss/jgitver/issues/Issue137Test.java
+++ b/src/test/java/fr/brouillard/oss/jgitver/issues/Issue137Test.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver.issues;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+import org.junit.jupiter.api.Test;
+
+import fr.brouillard.oss.jgitver.LookupPolicy;
+import fr.brouillard.oss.jgitver.ScenarioTest;
+import fr.brouillard.oss.jgitver.Scenarios;
+import fr.brouillard.oss.jgitver.Strategies;
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import java.util.Optional;
+import org.eclipse.jgit.api.MergeCommand;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for Issue #137.
+ */
+public class Issue137Test extends ScenarioTest {
+
+    private static final String BASE_TAG_STR = "1.2.3";
+    public Issue137Test() {
+        super(Issue137Test::init_scenario,
+                scenario -> scenario
+                        .setStrategy(Strategies.CONFIGURABLE)  // Need to use a strategy which actually records the commit distance
+                        .setLookupPolicy(LookupPolicy.MAX)
+        );
+    }
+
+    // Build a scenario where commit E has two parents: C and D.
+    // When FirstParentWalkDistanceCalculator gets to the point where it
+    // analyzes E it will already have analysed its first parent, C,
+    // via a different path (because C is also a child of F).
+    // See graph on GitHub issue.
+    // Until the fix for Issue-137 the commit D would never be analyzed.
+    // This scenario will test if FirstParentWalkDistanceCalculator will
+    // ever get to analyzing commit D as this is where we have the base tag.
+    public static Scenarios.Scenario init_scenario() {
+        return new Scenarios.ScenarioBuilder()
+                .commit("content", "A")
+                .branchOnAppId("branch1", "A")
+                .branchOnAppId("branch2", "A")
+                .master()
+                .commit("content", "B")
+                .checkoutBranch("branch1")
+                .commit("content", "C")
+                .checkoutBranch("branch2")
+                .commit("content", "D").tag(BASE_TAG_STR)
+                .branchOnAppId("branch3", "C")
+                .merge("D", "E", MergeCommand.FastForwardMode.NO_FF)
+                .master()
+                .merge("C", "F", MergeCommand.FastForwardMode.NO_FF)
+                .merge("E", "G", MergeCommand.FastForwardMode.NO_FF)
+                .getScenario();
+    }
+
+
+    @Test
+    public void check_commit_distance() {
+        Optional<String> optDistance = versionCalculator.meta(Metadatas.COMMIT_DISTANCE);
+        assertTrue(optDistance.isPresent());
+        assertThat(optDistance.get(), is("2"));
+    }
+
+
+    @Test
+    public void check_base_tag() {
+        Optional<String> optBaseTag = versionCalculator.meta(Metadatas.BASE_TAG);
+        assertTrue(optBaseTag.isPresent());
+        assertThat(optBaseTag.get(), is(BASE_TAG_STR));
+    }
+
+}


### PR DESCRIPTION
In  `FirstParentWalkDistanceCalculator`  :

Some parents were never traversed. Happened for commits where the first parent for that commit had already been analyzed (via a different path) but the other parents had not. In this situation the previous logic would "forget" to analyze those other parents. This would result in the `FirstParentWalkDistanceCalculator` incorrectly giving up on finding the target commit and therefore returning `Optional.empty()`.

Test case added.

Fixes #137 